### PR TITLE
Initial support for triggering and storing notifications

### DIFF
--- a/fixtures/encounter-er-visit.json
+++ b/fixtures/encounter-er-visit.json
@@ -1,0 +1,16 @@
+{
+	"resourceType": "Encounter",
+	"type": [{
+		"coding": [{
+			"system": "http://www.ama-assn.org/go/cpt",
+			"code": "99283"
+		}]
+	}],
+	"subject": {
+		"reference": "http://intervention-engine.org/Patient/5540f2041cd4623133000001"
+	},
+	"period": {
+		"start": "2015-04-01T05:15:00-04:00",
+		"end": "2015-04-03T12:30:00-04:00"
+	}
+}

--- a/fixtures/encounter-inpatient.json
+++ b/fixtures/encounter-inpatient.json
@@ -1,0 +1,17 @@
+{
+	"resourceType": "Encounter",
+	"type": [{
+		"coding": [{
+			"system": "http://snomed.info/sct",
+			"code": "32485007",
+			"display": "Hospital admission (procedure)"
+		}]
+	}],
+	"subject": {
+		"reference": "http://intervention-engine.org/Patient/5540f2041cd4623133000001"
+	},
+	"period": {
+		"start": "2015-04-01T05:15:00-04:00",
+		"end": "2015-04-03T12:30:00-04:00"
+	}
+}

--- a/fixtures/encounter-office-visit.json
+++ b/fixtures/encounter-office-visit.json
@@ -1,0 +1,16 @@
+{
+	"resourceType": "Encounter",
+	"type": [{
+		"coding": [{
+			"system": "http://www.ama-assn.org/go/cpt",
+			"code": "99201"
+		}]
+	}],
+	"subject": {
+		"reference": "http://intervention-engine.org/Patient/5540f2041cd4623133000001"
+	},
+	"period": {
+		"start": "2015-04-01T05:15:00-04:00",
+		"end": "2015-04-03T12:30:00-04:00"
+	}
+}

--- a/fixtures/encounter-planned.json
+++ b/fixtures/encounter-planned.json
@@ -1,0 +1,17 @@
+{
+	"resourceType": "Encounter",
+	"status": "planned",
+	"type": [{
+		"coding": [{
+			"system": "http://www.ama-assn.org/go/cpt",
+			"code": "99201"
+		}]
+	}],
+	"subject": {
+		"reference": "http://intervention-engine.org/Patient/5540f2041cd4623133000001"
+	},
+	"period": {
+		"start": "2015-04-01T05:15:00-04:00",
+		"end": "2015-04-03T12:30:00-04:00"
+	}
+}

--- a/fixtures/encounter-readmission.json
+++ b/fixtures/encounter-readmission.json
@@ -1,0 +1,23 @@
+{
+	"resourceType": "Encounter",
+	"type": [{
+		"coding": [{
+			"system": "http://snomed.info/sct",
+			"code": "417005",
+			"display": "Hospital re-admission (procedure)"
+		}]
+	}, {
+		"coding": [{
+			"system": "http://snomed.info/sct",
+			"code": "183452005",
+			"display": "Emergency hospital admission (procedure)"
+		}]
+	}],
+	"subject": {
+		"reference": "http://intervention-engine.org/Patient/5540f2041cd4623133000001"
+	},
+	"period": {
+		"start": "2015-04-01T05:15:00-04:00",
+		"end": "2015-04-03T12:30:00-04:00"
+	}
+}

--- a/middleware/notification_handler.go
+++ b/middleware/notification_handler.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/context"
+	"github.com/intervention-engine/fhir/server"
+	"github.com/intervention-engine/ie/notifications"
+)
+
+type NotificationHandler struct {
+	Registry *notifications.NotificationDefinitionRegistry
+}
+
+func (h *NotificationHandler) Handle(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	next(rw, r)
+	resourceType, ok := context.GetOk(r, "Resource")
+	if ok {
+		resource := context.Get(r, resourceType)
+		actionType := context.Get(r, "Action")
+
+		var reg *notifications.NotificationDefinitionRegistry
+		if h.Registry != nil {
+			reg = h.Registry
+		} else {
+			reg = notifications.DefaultNotificationDefinitionRegistry
+		}
+		for _, def := range reg.GetAll() {
+			if def.Triggers(resource, actionType.(string)) {
+				notification := def.GetNotification(resource, actionType.(string), h.getBaseURL(r))
+				err := server.Database.C("communicationrequests").Insert(notification)
+				if err != nil {
+					log.Printf("Error creating notification.\n\tNotification: %#v\n\tResource: %#v\n\tError: %#v", notification, resource, err)
+					http.Error(rw, err.Error(), http.StatusInternalServerError)
+				}
+			}
+		}
+	}
+}
+
+func (h *NotificationHandler) getBaseURL(r *http.Request) string {
+	newURL := url.URL(*r.URL)
+	if newURL.Host == "" {
+		newURL.Host = r.Host
+	}
+	if newURL.Scheme == "" {
+		if strings.HasSuffix(newURL.Host, ":443") {
+			newURL.Scheme = "https"
+		} else {
+			newURL.Scheme = "http"
+		}
+	}
+	newURL.Path = ""
+
+	return newURL.String()
+}

--- a/middleware/notification_handler_test.go
+++ b/middleware/notification_handler_test.go
@@ -1,0 +1,124 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/codegangsta/negroni"
+	"github.com/gorilla/mux"
+	"github.com/intervention-engine/fhir/models"
+	"github.com/intervention-engine/fhir/server"
+	"github.com/intervention-engine/ie/notifications"
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+)
+
+type NotificationHandlerSuite struct {
+	Session                *mgo.Session
+	Server                 *httptest.Server
+	Handler                *NotificationHandler
+	NotificationCollection *mgo.Collection
+}
+
+var _ = Suite(&NotificationHandlerSuite{})
+
+func (n *NotificationHandlerSuite) SetUpSuite(c *C) {
+	//Set up the database
+	var err error
+	n.Session, err = mgo.Dial("localhost")
+	util.CheckErr(err)
+	server.Database = n.Session.DB("ie-test")
+	n.NotificationCollection = server.Database.C("communicationrequests")
+	n.NotificationCollection.DropCollection()
+
+	//register notification handler middleware
+	n.Handler = &NotificationHandler{Registry: &notifications.NotificationDefinitionRegistry{}}
+	mwConfig := map[string][]negroni.Handler{
+		"EncounterCreate": []negroni.Handler{negroni.HandlerFunc(n.Handler.Handle)}}
+
+	//set up routes and middleware
+	router := mux.NewRouter()
+	router.StrictSlash(true)
+	router.KeepContext = true
+	server.RegisterRoutes(router, mwConfig)
+
+	//create test server
+	n.Server = httptest.NewServer(router)
+}
+
+func (n *NotificationHandlerSuite) TearDownSuite(c *C) {
+	n.Session.Close()
+	n.Server.Close()
+}
+
+func (n *NotificationHandlerSuite) TearDownTest(c *C) {
+	//clear the notification definition registry and the notification database
+	n.Handler.Registry = &notifications.NotificationDefinitionRegistry{}
+	n.NotificationCollection.DropCollection()
+}
+
+func (n *NotificationHandlerSuite) TestNotificationTriggers(c *C) {
+	n.Handler.Registry.Register(new(PlannedEncounterNotificationDefinition))
+	//load fixture
+	data, err := os.Open("../fixtures/encounter-planned.json")
+	defer data.Close()
+	util.CheckErr(err)
+
+	//post fixture
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", n.Server.URL+"/Encounter", data)
+	util.CheckErr(err)
+	_, err = client.Do(req)
+
+	//check for notification created
+	query := n.NotificationCollection.Find(nil)
+
+	//make sure there is only one
+	count, _ := query.Count()
+	c.Assert(count, Equals, 1)
+
+	//make sure it is the right one
+	result := models.CommunicationRequest{}
+	query.One(&result)
+	c.Assert(result.Id, Equals, "123")
+	c.Assert(result.Subject.Reference, Equals, "http://intervention-engine.org/Patient/5540f2041cd4623133000001")
+}
+
+func (n *NotificationHandlerSuite) TestNotificationDoesNotTrigger(c *C) {
+	n.Handler.Registry.Register(new(PlannedEncounterNotificationDefinition))
+
+	//load fixture
+	data, err := os.Open("../fixtures/encounter-office-visit.json")
+	defer data.Close()
+	util.CheckErr(err)
+
+	//post fixture
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", n.Server.URL+"/Encounter", data)
+	util.CheckErr(err)
+	_, err = client.Do(req)
+
+	//check for no notification
+	count, err := n.NotificationCollection.Count()
+	c.Assert(count, Equals, 0)
+}
+
+//  Dummy notification definition for testing
+type PlannedEncounterNotificationDefinition struct{}
+
+func (def *PlannedEncounterNotificationDefinition) Name() string {
+	return "Planned Encounter"
+}
+func (def *PlannedEncounterNotificationDefinition) Triggers(resource interface{}, action string) bool {
+	enc, ok := resource.(*models.Encounter)
+	return action == "create" && ok && enc.Status == "planned"
+}
+func (def *PlannedEncounterNotificationDefinition) GetNotification(resource interface{}, action string, baseURL string) *models.CommunicationRequest {
+	if def.Triggers(resource, action) {
+		enc := resource.(*models.Encounter)
+		return &models.CommunicationRequest{Id: "123", Subject: enc.Subject}
+	}
+	return nil
+}

--- a/notifications/encounter_type_notification.go
+++ b/notifications/encounter_type_notification.go
@@ -1,0 +1,137 @@
+package notifications
+
+import (
+	"time"
+
+	"github.com/intervention-engine/fhir/models"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func init() {
+	DefaultNotificationDefinitionRegistry.RegisterAll([]NotificationDefinition{
+		AdmissionNotificationDefinition,
+		ReadmissionNotificationDefinition,
+		ERVisitNotificationDefinition})
+}
+
+type EncounterTypeNotificationDefinition struct {
+	name                  string
+	types                 []models.Coding
+	reason                models.Coding
+	additionalConstraints func(resource interface{}, action string) bool
+}
+
+func (def *EncounterTypeNotificationDefinition) Name() string {
+	return def.name
+}
+
+func (def *EncounterTypeNotificationDefinition) Triggers(resource interface{}, action string) bool {
+	if action != "create" {
+		return false
+	}
+
+	encounter, ok := resource.(*models.Encounter)
+	if ok && models.CodeableConcepts(encounter.Type).AnyMatchesAnyCode(def.types) {
+		if def.additionalConstraints != nil {
+			return def.additionalConstraints(resource, action)
+		}
+		return true
+	}
+	return false
+}
+
+func (def *EncounterTypeNotificationDefinition) GetNotification(resource interface{}, action string, baseURL string) *models.CommunicationRequest {
+	if def.Triggers(resource, action) {
+		encounter := resource.(*models.Encounter)
+		cr := models.CommunicationRequest{}
+		cr.Id = bson.NewObjectId().Hex()
+		cr.Category = &models.CodeableConcept{Coding: make([]models.Coding, 1)}
+		cr.Category.Coding[0].System = "http://snomed.info/sct"
+		cr.Category.Coding[0].Code = "185087000"
+		//cr.Recipient = TODO
+		cr.Payload = make([]models.CommunicationRequestPayloadComponent, 1)
+		cr.Payload[0].ContentReference = &models.Reference{Reference: baseURL + "/Encounter/" + encounter.Id}
+		cr.Status = "requested"
+		cr.Reason = make([]models.CodeableConcept, 1)
+		cr.Reason[0] = models.CodeableConcept{Coding: make([]models.Coding, 1)}
+		cr.Reason[0].Coding[0] = def.reason
+		cr.Subject = encounter.Subject
+		cr.OrderedOn = &models.FHIRDateTime{Precision: models.Timestamp, Time: time.Now()}
+		return &cr
+	}
+	return nil
+}
+
+// Definition of Encounter-based Notifications.  In the future, this could be externalized to a configuration file or database.
+
+var AdmissionNotificationDefinition = &EncounterTypeNotificationDefinition{
+	name:   "Inpatient Admission",
+	reason: models.Coding{System: "http://snomed.info/sct", Code: "32485007", Display: "Hospital admission (procedure)"},
+	additionalConstraints: func(resource interface{}, action string) bool {
+		// Don't trigger the admission notification if it's also a re-admission
+		return !ReadmissionNotificationDefinition.Triggers(resource, action)
+	},
+	types: []models.Coding{
+		models.Coding{System: "http://snomed.info/sct", Code: "10378005", Display: "Hospital admission, emergency, from emergency room, accidental injury (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "112689000", Display: "Hospital admission, elective, with complete pre-admission work-up (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "112690009", Display: "Hospital admission, boarder, for social reasons (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "1505002", Display: "Hospital admission for isolation (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "15584006", Display: "Hospital admission, elective, with partial pre-admission work-up (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "18083007", Display: "Hospital admission, emergency, indirect (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "183430001", Display: "Holiday relief admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "183452005", Display: "Emergency hospital admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "183477006", Display: "Admit cardiothoracic emergency (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "183481006", Display: "Non-urgent hospital admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "183497001", Display: "Non-urgent trauma admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "19951005", Display: "Hospital admission, emergency, from emergency room, medical nature (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "2252009", Display: "Hospital admission, urgent, 48 hours (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "23473000", Display: "Hospital admission, for research investigation (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "25986004", Display: "Hospital admission, under police custody (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "266938001", Display: "Hospital patient (finding)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "2876009", Display: "Hospital admission, type unclassified, explain by report (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "304568006", Display: "Admission for respite care (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305335007", Display: "Admission to establishment (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305337004", Display: "Admission to community hospital (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305338009", Display: "Admission to general practice hospital (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305339001", Display: "Admission to private hospital (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305341000", Display: "Admission to tertiary referral hospital (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305342007", Display: "Admission to ward (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305343002", Display: "Admission to day ward (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "305344008", Display: "Admission to day hospital (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "308540004", Display: "Inpatient stay (finding)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "313385005", Display: "Admit cardiology emergency (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "32485007", Display: "Hospital admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "36723004", Display: "Hospital admission, pre-nursing home placement (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "394656005", Display: "Inpatient care (regime/therapy)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "405614004", Display: "Unexpected hospital admission (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "416683003", Display: "Admit heart failure emergency (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "4563007", Display: "Hospital admission, transfer from other hospital or health care facility (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "45702004", Display: "Hospital admission, precertified by medical audit action (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "48183000", Display: "Hospital admission, special (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "50699000", Display: "Hospital admission, short-term (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "52748007", Display: "Hospital admission, involuntary (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "55402005", Display: "Hospital admission, for laboratory work-up, radiography, etc. (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "63551005", Display: "Hospital admission, from remote area, by means of special transportation (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "65043002", Display: "Hospital admission, short-term, day care (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "70755000", Display: "Hospital admission, by legal authority (commitment) (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "71290004", Display: "Hospital admission, limited to designated procedures (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "73607007", Display: "Hospital admission, emergency, from emergency room (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "78680009", Display: "Hospital admission, emergency, direct (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "81672003", Display: "Hospital admission, elective, without pre-admission work-up (procedure)"},
+		models.Coding{System: "http://snomed.info/sct", Code: "8715000", Display: "Hospital admission, elective (procedure)"}}}
+
+var ReadmissionNotificationDefinition = &EncounterTypeNotificationDefinition{
+	name:   "Readmission",
+	reason: models.Coding{System: "http://snomed.info/sct", Code: "417005", Display: "Hospital re-admission (procedure)"},
+	types:  []models.Coding{models.Coding{System: "http://snomed.info/sct", Code: "417005", Display: "Hospital re-admission (procedure)"}}}
+
+var ERVisitNotificationDefinition = &EncounterTypeNotificationDefinition{
+	name:   "ER Visit",
+	reason: models.Coding{System: "http://snomed.info/sct", Code: "4525004", Display: "Emergency department patient visit (procedure)"},
+	types: []models.Coding{
+		models.Coding{System: "http://snomed.info/sct", Code: "4525004", Display: "Emergency department patient visit (procedure)"},
+		models.Coding{System: "http://www.ama-assn.org/go/cpt", Code: "99281", Display: "Emergency department visit..."},
+		models.Coding{System: "http://www.ama-assn.org/go/cpt", Code: "99282", Display: "Emergency department visit..."},
+		models.Coding{System: "http://www.ama-assn.org/go/cpt", Code: "99283", Display: "Emergency department visit..."},
+		models.Coding{System: "http://www.ama-assn.org/go/cpt", Code: "99284", Display: "Emergency department visit..."},
+		models.Coding{System: "http://www.ama-assn.org/go/cpt", Code: "99285", Display: "Emergency department visit..."}}}

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,0 +1,30 @@
+package notifications
+
+import "github.com/intervention-engine/fhir/models"
+
+/* The NotificationDefinition interface should be implemented by all notification definitions */
+type NotificationDefinition interface {
+	Name() string
+	Triggers(resource interface{}, action string) bool
+	GetNotification(resource interface{}, action string, baseURL string) *models.CommunicationRequest
+}
+
+// Setup the registry that keeps track of all the notification definitions
+
+type NotificationDefinitionRegistry struct {
+	defs []NotificationDefinition
+}
+
+func (r *NotificationDefinitionRegistry) Register(def NotificationDefinition) {
+	r.defs = append(r.defs, def)
+}
+
+func (r *NotificationDefinitionRegistry) RegisterAll(slice []NotificationDefinition) {
+	r.defs = append(r.defs, slice...)
+}
+
+func (r *NotificationDefinitionRegistry) GetAll() []NotificationDefinition {
+	return r.defs
+}
+
+var DefaultNotificationDefinitionRegistry = new(NotificationDefinitionRegistry)

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -1,0 +1,147 @@
+package notifications
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+)
+
+type NotificationSuite struct{}
+
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&NotificationSuite{})
+
+func (n *NotificationSuite) TestInpatientAdmissionNotifications(c *C) {
+	encounter, err := UnmarshallEncounter("../fixtures/encounter-inpatient.json")
+	util.CheckErr(err)
+
+	count := 0
+	for _, def := range DefaultNotificationDefinitionRegistry.GetAll() {
+		if def.Triggers(encounter, "create") {
+			count++
+			c.Assert(def.Name(), Equals, "Inpatient Admission")
+			cr := def.GetNotification(encounter, "create", "http://intervention-engine.org")
+			AssertEncounterNotificationContents(cr, &models.Coding{System: "http://snomed.info/sct", Code: "32485007"}, c)
+		}
+		c.Assert(def.Triggers(encounter, "update"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "update", "http://intervention-engine.org"), IsNil)
+		c.Assert(def.Triggers(encounter, "delete"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "delete", "http://intervention-engine.org"), IsNil)
+
+	}
+	c.Assert(count, Equals, 1)
+}
+
+func (n *NotificationSuite) TestReadmissionNotifications(c *C) {
+	encounter, err := UnmarshallEncounter("../fixtures/encounter-readmission.json")
+	util.CheckErr(err)
+
+	count := 0
+	for _, def := range DefaultNotificationDefinitionRegistry.GetAll() {
+		if def.Triggers(encounter, "create") {
+			count++
+			c.Assert(def.Name(), Equals, "Readmission")
+			cr := def.GetNotification(encounter, "create", "http://intervention-engine.org")
+			AssertEncounterNotificationContents(cr, &models.Coding{System: "http://snomed.info/sct", Code: "417005"}, c)
+		}
+		c.Assert(def.Triggers(encounter, "update"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "update", "http://intervention-engine.org"), IsNil)
+		c.Assert(def.Triggers(encounter, "delete"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "delete", "http://intervention-engine.org"), IsNil)
+
+	}
+	c.Assert(count, Equals, 1)
+}
+
+func (n *NotificationSuite) TestERVisitNotifications(c *C) {
+	encounter, err := UnmarshallEncounter("../fixtures/encounter-er-visit.json")
+	util.CheckErr(err)
+
+	count := 0
+	for _, def := range DefaultNotificationDefinitionRegistry.GetAll() {
+		if def.Triggers(encounter, "create") {
+			count++
+			c.Assert(def.Name(), Equals, "ER Visit")
+			cr := def.GetNotification(encounter, "create", "http://intervention-engine.org")
+			AssertEncounterNotificationContents(cr, &models.Coding{System: "http://snomed.info/sct", Code: "4525004"}, c)
+		}
+		c.Assert(def.Triggers(encounter, "update"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "update", "http://intervention-engine.org"), IsNil)
+		c.Assert(def.Triggers(encounter, "delete"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "delete", "http://intervention-engine.org"), IsNil)
+
+	}
+	c.Assert(count, Equals, 1)
+}
+
+func (n *NotificationSuite) TestOfficeVisitDoesNotTriggerNoNotifications(c *C) {
+	encounter, err := UnmarshallEncounter("../fixtures/encounter-office-visit.json")
+	util.CheckErr(err)
+
+	for _, def := range DefaultNotificationDefinitionRegistry.GetAll() {
+		c.Assert(def.Triggers(encounter, "create"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "create", "http://intervention-engine.org"), IsNil)
+		c.Assert(def.Triggers(encounter, "update"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "update", "http://intervention-engine.org"), IsNil)
+		c.Assert(def.Triggers(encounter, "delete"), Equals, false)
+		c.Assert(def.GetNotification(encounter, "delete", "http://intervention-engine.org"), IsNil)
+
+	}
+}
+
+func (n *NotificationSuite) TestNotificationDefinitionRegistration(c *C) {
+	defs := DefaultNotificationDefinitionRegistry.GetAll()
+	c.Assert(defs, HasLen, 3)
+	c.Assert(IsRegistered(AdmissionNotificationDefinition), Equals, true)
+	c.Assert(IsRegistered(ReadmissionNotificationDefinition), Equals, true)
+	c.Assert(IsRegistered(ERVisitNotificationDefinition), Equals, true)
+}
+
+func AssertEncounterNotificationContents(cr *models.CommunicationRequest, reason *models.Coding, c *C) {
+	c.Assert(cr.Id, NotNil)
+	c.Assert(cr.Category.Coding, HasLen, 1)
+	c.Assert(cr.Category.Coding[0].System, Equals, "http://snomed.info/sct")
+	c.Assert(cr.Category.Coding[0].Code, Equals, "185087000")
+	c.Assert(cr.Payload, HasLen, 1)
+	c.Assert(cr.Payload[0].ContentReference.Reference, Equals, "http://intervention-engine.org/Encounter/1")
+	c.Assert(cr.Status, Equals, "requested")
+	c.Assert(cr.Reason, HasLen, 1)
+	c.Assert(cr.Reason[0].Coding, HasLen, 1)
+	c.Assert(cr.Reason[0].Coding[0].System, Equals, reason.System)
+	c.Assert(cr.Reason[0].Coding[0].Code, Equals, reason.Code)
+	c.Assert(cr.Subject.Reference, Matches, ".*/Patient/5540f2041cd4623133000001")
+	c.Assert(cr.OrderedOn.Precision, Equals, models.Precision(models.Timestamp))
+	c.Assert(cr.OrderedOn.Time.Before(time.Now()), Equals, true)
+	c.Assert(time.Now().Sub(cr.OrderedOn.Time) < time.Duration(5)*time.Minute, Equals, true)
+}
+
+func IsRegistered(n NotificationDefinition) bool {
+	for _, def := range DefaultNotificationDefinitionRegistry.GetAll() {
+		if def == n {
+			return true
+		}
+	}
+	return false
+}
+
+func UnmarshallEncounter(file string) (*models.Encounter, error) {
+	data, err := os.Open(file)
+	defer data.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(data)
+	encounter := &models.Encounter{}
+	err = decoder.Decode(encounter)
+	if err == nil {
+		encounter.Id = "1"
+	}
+	return encounter, err
+}

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/intervention-engine/fhir/server"
 	"github.com/intervention-engine/ie/controllers"
 	"github.com/intervention-engine/ie/middleware"
+	"github.com/intervention-engine/ie/notifications"
 	"os"
 )
 
@@ -38,6 +39,10 @@ func main() {
 	s.AddMiddleware("MedicationStatementCreate", negroni.HandlerFunc(middleware.FactHandler))
 	s.AddMiddleware("MedicationStatementUpdate", negroni.HandlerFunc(middleware.FactHandler))
 	s.AddMiddleware("MedicationStatementDelete", negroni.HandlerFunc(middleware.FactHandler))
+
+	// Setup the notification handler to use the default notification definitions (and then register it)
+	notificationHandler := &middleware.NotificationHandler{Registry: notifications.DefaultNotificationDefinitionRegistry}
+	s.AddMiddleware("EncounterCreate", negroni.HandlerFunc(notificationHandler.Handle))
 
 	s.Router.HandleFunc("/QueryConditionTotal/{id}", controllers.ConditionTotalHandler)
 	s.Router.HandleFunc("/QueryEncounterTotal/{id}", controllers.EncounterTotalHandler)


### PR DESCRIPTION
This pull request adds support for triggering and storing notifications.  The notificaton definition interface and specific notification definitions are in the `notifications` package.  The notification handler is in the `middleware` package.  Currently only the code-based notifications are supported: Inpatient Encounter, Re-Admission, and ER Visit.

This pull request depends on https://github.com/intervention-engine/fhir/pull/5.

This is my first attempt (ever) at writing Go, so I appreciate a full code-review (although this is mainly just following the same template as all the other resources).
