### PR TITLE
Notification counts

### DIFF
--- a/controllers/notification_count.go
+++ b/controllers/notification_count.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"encoding/json"
+	"github.com/intervention-engine/fhir/server"
+	"gopkg.in/mgo.v2/bson"
+	"log"
+	"net/http"
+)
+
+func NotificationCountHandler(rw http.ResponseWriter, r *http.Request) {
+	pipe := server.Database.C("communicationrequests").Pipe([]bson.M{{"$group": bson.M{"_id": "$subject.referenceid", "count": bson.M{"$sum": 1}}}})
+	var results []struct {
+		Patient string  `bson:"_id" json:"patient"`
+		Count   float64 `bson:"count" json:"count"`
+	}
+	err := pipe.All(&results)
+	if err != nil {
+		log.Printf("Error getting notification count: %#v", err)
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+	} else {
+		json.NewEncoder(rw).Encode(results)
+	}
+}

--- a/controllers/notification_count.go
+++ b/controllers/notification_count.go
@@ -10,10 +10,7 @@ import (
 
 func NotificationCountHandler(rw http.ResponseWriter, r *http.Request) {
 	pipe := server.Database.C("communicationrequests").Pipe([]bson.M{{"$group": bson.M{"_id": "$subject.referenceid", "count": bson.M{"$sum": 1}}}})
-	var results []struct {
-		Patient string  `bson:"_id" json:"patient"`
-		Count   float64 `bson:"count" json:"count"`
-	}
+	var results []NotificationCountResult
 	err := pipe.All(&results)
 	if err != nil {
 		log.Printf("Error getting notification count: %#v", err)
@@ -21,4 +18,9 @@ func NotificationCountHandler(rw http.ResponseWriter, r *http.Request) {
 	} else {
 		json.NewEncoder(rw).Encode(results)
 	}
+}
+
+type NotificationCountResult struct {
+	Patient string  `bson:"_id" json:"patient"`
+	Count   float64 `bson:"count" json:"count"`
 }

--- a/controllers/notification_count_test.go
+++ b/controllers/notification_count_test.go
@@ -51,7 +51,7 @@ func (n *NotificationCountSuite) TestEmptyNotificationCount(c *C) {
 		c.Fatal("Non-OK response code received: %v", w.Code)
 	}
 
-	counts := make([]interface{}, 0, 1)
+	var counts []NotificationCountResult
 	err := json.NewDecoder(w.Body).Decode(&counts)
 	util.CheckErr(err)
 
@@ -78,11 +78,7 @@ func (n *NotificationCountSuite) TestNotificationCount(c *C) {
 		c.Fatal("Non-OK response code received: %v", w.Code)
 	}
 
-	type Count struct {
-		Patient string  `json:"patient"`
-		Count   float64 `json:"count"`
-	}
-	counts := make([]Count, 0, 3)
+	var counts []NotificationCountResult
 	err = json.NewDecoder(w.Body).Decode(&counts)
 	util.CheckErr(err)
 

--- a/controllers/notification_count_test.go
+++ b/controllers/notification_count_test.go
@@ -1,0 +1,109 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/intervention-engine/fhir/server"
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+)
+
+type NotificationCountSuite struct {
+	Session                *mgo.Session
+	NotificationCollection *mgo.Collection
+}
+
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&NotificationCountSuite{})
+
+func (n *NotificationCountSuite) SetUpSuite(c *C) {
+	//Set up the database
+	var err error
+	n.Session, err = mgo.Dial("localhost")
+	util.CheckErr(err)
+	server.Database = n.Session.DB("ie-test")
+	n.NotificationCollection = server.Database.C("communicationrequests")
+	n.NotificationCollection.DropCollection()
+}
+
+func (n *NotificationCountSuite) TearDownSuite(c *C) {
+	n.Session.Close()
+}
+
+func (n *NotificationCountSuite) TearDownTest(c *C) {
+	//clear the notification database
+	n.NotificationCollection.DropCollection()
+}
+
+func (n *NotificationCountSuite) TestEmptyNotificationCount(c *C) {
+	handler := NotificationCountHandler
+	req, _ := http.NewRequest("GET", "/NotificationCount", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+	if w.Code != http.StatusOK {
+		c.Fatal("Non-OK response code received: %v", w.Code)
+	}
+
+	counts := make([]interface{}, 0, 1)
+	err := json.NewDecoder(w.Body).Decode(&counts)
+	util.CheckErr(err)
+
+	c.Assert(counts, HasLen, 0)
+}
+
+func (n *NotificationCountSuite) TestNotificationCount(c *C) {
+	notification, err := UnmarshallCommunicationRequest("../fixtures/communication-request.json")
+	util.CheckErr(err)
+
+	for i, id := range []string{"a", "b", "c", "b", "b", "a"} {
+		notification.Id = string(i)
+		notification.Subject.Reference = "http://test-ie/Patient/" + id
+		notification.Subject.ReferencedID = id
+		err = n.NotificationCollection.Insert(*notification)
+		util.CheckErr(err)
+	}
+
+	handler := NotificationCountHandler
+	req, _ := http.NewRequest("GET", "/NotificationCount", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+	if w.Code != http.StatusOK {
+		c.Fatal("Non-OK response code received: %v", w.Code)
+	}
+
+	type Count struct {
+		Patient string  `json:"patient"`
+		Count   float64 `json:"count"`
+	}
+	counts := make([]Count, 0, 3)
+	err = json.NewDecoder(w.Body).Decode(&counts)
+	util.CheckErr(err)
+
+	c.Assert(counts, HasLen, 3)
+	m := make(map[string]int)
+	for _, count := range counts {
+		m[count.Patient] = int(count.Count)
+	}
+	c.Assert(m["a"], Equals, 2)
+	c.Assert(m["b"], Equals, 3)
+	c.Assert(m["c"], Equals, 1)
+}
+
+func UnmarshallCommunicationRequest(file string) (*models.CommunicationRequest, error) {
+	data, err := os.Open(file)
+	defer data.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	cr := &models.CommunicationRequest{}
+	err = json.NewDecoder(data).Decode(cr)
+	return cr, err
+}

--- a/fixtures/communication-request.json
+++ b/fixtures/communication-request.json
@@ -1,0 +1,29 @@
+{
+	"category": {
+		"coding": [{
+			"system": "http://snomed.info/sct",
+			"code": "185087000"
+		}]
+	},
+	"payload": [{
+		"contentReference": {
+			"reference": "http://localhost:3001/Encounter/5564865619d2504cba00006e",
+			"type": "Encounter",
+			"referenceid": "5564865619d2504cba00006e"
+		}
+	}],
+	"status": "requested",
+	"reason": [{
+		"coding": [{
+			"system": "http://snomed.info/sct",
+			"code": "32485007",
+			"display": "Hospital admission (procedure)"
+		}]
+	}],
+	"orderedOn": "2015-05-26T10:42:30-04:00",
+	"subject": {
+		"reference": "http://MM198075-PC:3001/Patient/5564865619d2504cba00006c",
+		"type": "Patient",
+		"referenceid": "5564865619d2504cba00006c"
+	}
+}

--- a/notifications/encounter_type_notification.go
+++ b/notifications/encounter_type_notification.go
@@ -50,7 +50,10 @@ func (def *EncounterTypeNotificationDefinition) GetNotification(resource interfa
 		cr.Category.Coding[0].Code = "185087000"
 		//cr.Recipient = TODO
 		cr.Payload = make([]models.CommunicationRequestPayloadComponent, 1)
-		cr.Payload[0].ContentReference = &models.Reference{Reference: baseURL + "/Encounter/" + encounter.Id}
+		cr.Payload[0].ContentReference = &models.Reference{
+			Reference:    baseURL + "/Encounter/" + encounter.Id,
+			Type:         "Encounter",
+			ReferencedID: encounter.Id}
 		cr.Status = "requested"
 		cr.Reason = make([]models.CodeableConcept, 1)
 		cr.Reason[0] = models.CodeableConcept{Coding: make([]models.Coding, 1)}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -110,6 +110,8 @@ func AssertEncounterNotificationContents(cr *models.CommunicationRequest, reason
 	c.Assert(cr.Category.Coding[0].Code, Equals, "185087000")
 	c.Assert(cr.Payload, HasLen, 1)
 	c.Assert(cr.Payload[0].ContentReference.Reference, Equals, "http://intervention-engine.org/Encounter/1")
+	c.Assert(cr.Payload[0].ContentReference.ReferencedID, Equals, "1")
+	c.Assert(cr.Payload[0].ContentReference.Type, Equals, "Encounter")
 	c.Assert(cr.Status, Equals, "requested")
 	c.Assert(cr.Reason, HasLen, 1)
 	c.Assert(cr.Reason[0].Coding, HasLen, 1)

--- a/server.go
+++ b/server.go
@@ -49,6 +49,7 @@ func main() {
 	s.Router.HandleFunc("/QueryEncounterTotal/{id}", controllers.EncounterTotalHandler)
 	s.Router.HandleFunc("/QueryList/{id}", controllers.PatientListHandler)
 	s.Router.HandleFunc("/InstaCount/{type}", controllers.InstaCountHandler)
+	s.Router.HandleFunc("/NotificationCount", controllers.NotificationCountHandler)
 
 	filterBase := s.Router.Path("/Filter").Subrouter()
 	filterBase.Methods("GET").Handler(negroni.New(negroni.HandlerFunc(controllers.FilterIndexHandler)))


### PR DESCRIPTION
The NotificationCount controller returns a simple array of hashes, each containing a patient id and the number of notifications that patient has.  Patients with 0 notifications are not represented at all.

This controller supports the patient index UI that displays notification counts in the patient badges.
