### PR TITLE
Changes to how the fact creation happens for observations

### DIFF
--- a/models/fact.go
+++ b/models/fact.go
@@ -60,8 +60,7 @@ func FactFromEncounter(e *models.Encounter) Fact {
 func FactFromObservation(o *models.Observation) Fact {
 	f := Fact{}
 	f.Type = "Observation"
-	f.StartDate = o.EffectivePeriod.Start
-	f.EndDate = o.EffectivePeriod.End
+	f.StartDate = o.EffectiveDateTime
 	f.ResultQuantity = o.ValueQuantity
 	f.ResultCodeableConcept = o.ValueCodeableConcept
 	f.Codes = []models.CodeableConcept{*o.Code}


### PR DESCRIPTION
This now uses EffectiveDateTime instead of EffectivePeriod. This is
better for a few reasons:
- The fact creation would panic if an Effective Period was not
  present. Now it should work regardless of whether EffectiveDateTime is
  there or not.
- For most Observations EffectiveDateTime makes more sense than using
  a period.

There were no corresponding tests to update here and I'm not really
concerned since we will be tossing this code when we refactor the
pipeline.
