### PR TITLE
Now requesting risk assessment calculation on encounter creation

### DIFF
--- a/server.go
+++ b/server.go
@@ -71,6 +71,7 @@ func main() {
 	s.AddMiddleware("ConditionDelete", negroni.HandlerFunc(middleware.FactHandler))
 
 	s.AddMiddleware("EncounterCreate", negroni.HandlerFunc(middleware.FactHandler))
+	s.AddMiddleware("EncounterCreate", watch)
 	s.AddMiddleware("EncounterUpdate", negroni.HandlerFunc(middleware.FactHandler))
 	s.AddMiddleware("EncounterDelete", negroni.HandlerFunc(middleware.FactHandler))
 

--- a/subscription/resource_watch.go
+++ b/subscription/resource_watch.go
@@ -26,6 +26,9 @@ func GenerateResourceWatch(subUpdateQueue chan<- ResourceUpdateMessage) negroni.
 			case *fhirmodels.MedicationStatement:
 				patientID = resource.(*fhirmodels.MedicationStatement).Patient.ReferencedID
 				timestamp = resource.(*fhirmodels.MedicationStatement).EffectivePeriod.Start.Time
+			case *fhirmodels.Encounter:
+				patientID = resource.(*fhirmodels.Encounter).Patient.ReferencedID
+				timestamp = resource.(*fhirmodels.Encounter).Period.Start.Time
 			}
 
 			ru := NewResourceUpdateMessage(patientID, timestamp.Format(time.RFC3339))


### PR DESCRIPTION
This triggers risk assessment calculation on encounters. Previously, it was only on MedicationStatements and Conditions. This helps out the display of the risk histogram in a number of ways:
- It better picks up conditions that have ended
- It expands the timeline for "uneventful" patients
