### PR TITLE
Fix places where a nil object might be accessed

### DIFF
--- a/controllers/code_lookup_test.go
+++ b/controllers/code_lookup_test.go
@@ -26,8 +26,8 @@ func (l *CodeLookupSuite) SetUpSuite(c *C) {
 	l.DBServer.SetPath(c.MkDir())
 
 	file, err := os.Open("../fixtures/code-lookup.json")
-	defer file.Close()
 	util.CheckErr(err)
+	defer file.Close()
 
 	session := l.DBServer.Session()
 	lookupCollection := session.DB("ie-test").C("codelookup")

--- a/controllers/group_totals_test.go
+++ b/controllers/group_totals_test.go
@@ -26,16 +26,16 @@ func (q *QueryTotalsSuite) SetUpSuite(c *C) {
 
 func (q *QueryTotalsSuite) SetUpTest(c *C) {
 	patientFile, err := os.Open("../fixtures/patient-example-a.json")
-	defer patientFile.Close()
 	util.CheckErr(err)
+	defer patientFile.Close()
 
 	encounterFile, err := os.Open("../fixtures/encounter-example.json")
-	defer encounterFile.Close()
 	util.CheckErr(err)
+	defer encounterFile.Close()
 
 	conditionFile, err := os.Open("../fixtures/condition-example.json")
-	defer conditionFile.Close()
 	util.CheckErr(err)
+	defer conditionFile.Close()
 
 	// Setup the database
 	session := q.DBServer.Session()

--- a/controllers/notification_count_test.go
+++ b/controllers/notification_count_test.go
@@ -96,10 +96,10 @@ func (n *NotificationCountSuite) TestNotificationCount(c *C) {
 
 func UnmarshallCommunicationRequest(file string) (*models.CommunicationRequest, error) {
 	data, err := os.Open(file)
-	defer data.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer data.Close()
 
 	cr := &models.CommunicationRequest{}
 	err = json.NewDecoder(data).Decode(cr)

--- a/middleware/notification_handler_test.go
+++ b/middleware/notification_handler_test.go
@@ -66,8 +66,8 @@ func (n *NotificationHandlerSuite) TestNotificationTriggers(c *C) {
 	n.Handler.Registry.Register(new(PlannedEncounterNotificationDefinition))
 	//load fixture
 	data, err := os.Open("../fixtures/encounter-planned.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 
 	//post fixture
 	client := &http.Client{}
@@ -94,8 +94,8 @@ func (n *NotificationHandlerSuite) TestNotificationDoesNotTrigger(c *C) {
 
 	//load fixture
 	data, err := os.Open("../fixtures/encounter-office-visit.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 
 	//post fixture
 	client := &http.Client{}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -134,10 +134,10 @@ func IsRegistered(n NotificationDefinition) bool {
 
 func UnmarshallEncounter(file string) (*models.Encounter, error) {
 	data, err := os.Open(file)
-	defer data.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer data.Close()
 
 	decoder := json.NewDecoder(data)
 	encounter := &models.Encounter{}

--- a/subscription/resource_watch_test.go
+++ b/subscription/resource_watch_test.go
@@ -62,8 +62,8 @@ func (r *ResourceWatchSuite) TearDownSuite(c *C) {
 func (r *ResourceWatchSuite) TestGenerateResourceWatch(c *C) {
 	//load fixture
 	data, err := os.Open("../fixtures/medication-statement.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 
 	//post fixture
 	client := &http.Client{}


### PR DESCRIPTION
While `defer data.Close()` is generally _good_, it's important to call it only after you've verified that `data` was successfully opened in the first place.  Otherwise, you're trying to call a function on a nil object.
