### PR TITLE
Base Resource Support

### DIFF
--- a/middleware/notification_handler_test.go
+++ b/middleware/notification_handler_test.go
@@ -121,7 +121,9 @@ func (def *PlannedEncounterNotificationDefinition) Triggers(resource interface{}
 func (def *PlannedEncounterNotificationDefinition) GetNotification(resource interface{}, action string, baseURL string) *models.CommunicationRequest {
 	if def.Triggers(resource, action) {
 		enc := resource.(*models.Encounter)
-		return &models.CommunicationRequest{Id: "123", Subject: enc.Patient}
+		cr := &models.CommunicationRequest{}
+		cr.Id = "123"
+		cr.Subject = enc.Patient
 	}
 	return nil
 }


### PR DESCRIPTION
See [FHIR PR #25](https://github.com/intervention-engine/fhir/pull/25) for details on support for base resources.

This PR just fixes a test that no longer compiled after the base resource changes.
