### PR TITLE
Changes to make IE usable within other applications

### DIFF
--- a/controllers/routes.go
+++ b/controllers/routes.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"sync"
+
+	"github.com/intervention-engine/fhir/server"
+	"github.com/intervention-engine/ie/middleware"
+	"github.com/intervention-engine/ie/notifications"
+	"github.com/intervention-engine/ie/subscription"
+)
+
+func RegisterRoutes(s *server.FHIRServer, selfURL, riskServiceEndpoint string) {
+	workerChannel := make(chan subscription.ResourceUpdateMessage)
+	watch := subscription.GenerateResourceWatch(workerChannel)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go subscription.NotifySubscribers(workerChannel, selfURL, &wg)
+	defer stopNotifier(workerChannel, &wg)
+	s.AddMiddleware("Group", middleware.AuthHandler())
+
+	s.AddMiddleware("Patient", middleware.AuthHandler())
+
+	s.AddMiddleware("Condition", watch)
+
+	s.AddMiddleware("MedicationStatement", watch)
+
+	s.AddMiddleware("Encounter", watch)
+
+	s.AddMiddleware("Batch", watch)
+
+	// Setup the notification handler to use the default notification definitions (and then register it)
+	notificationHandler := &middleware.NotificationHandler{Registry: notifications.DefaultNotificationDefinitionRegistry}
+	s.AddMiddleware("Encounter", notificationHandler.Handle())
+
+	s.Echo.Get("/GroupList/:id", PatientListHandler)
+	s.Echo.Post("/InstaCountAll", InstaCountAllHandler)
+	s.Echo.Get("/NotificationCount", NotificationCountHandler)
+	s.Echo.Get("/Pie/:id", GeneratePieHandler(riskServiceEndpoint))
+	s.Echo.Post("/CodeLookup", CodeLookup)
+
+	login := s.Echo.Group("/login")
+	login.Post("", LoginHandler)
+	login.Delete("", LogoutHandler)
+}
+
+func stopNotifier(wc chan subscription.ResourceUpdateMessage, wg *sync.WaitGroup) {
+	close(wc)
+	wg.Wait()
+}


### PR DESCRIPTION
Creating a RegisterRoutes function that takes a FHIRServer and other URLs. This
will let other applications include IE if they want to run it as part of a
larger application.
