### PR TITLE
Minor updates to use of dbtest.DBServer in tests

### DIFF
--- a/controllers/code_lookup_test.go
+++ b/controllers/code_lookup_test.go
@@ -32,9 +32,8 @@ func (l *CodeLookupSuite) SetUpSuite(c *C) {
 	util.CheckErr(err)
 	defer file.Close()
 
-	session := l.DBServer.Session()
-	lookupCollection := session.DB("ie-test").C("codelookup")
-	lookupCollection.DropCollection()
+	server.Database = l.DBServer.Session().DB("ie-test")
+	lookupCollection := server.Database.C("codelookup")
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		decoder := json.NewDecoder(strings.NewReader(scanner.Text()))
@@ -44,13 +43,11 @@ func (l *CodeLookupSuite) SetUpSuite(c *C) {
 		lookupCollection.Insert(entry)
 	}
 	util.CheckErr(scanner.Err())
-
-	server.Database = session.DB("ie-test")
 }
 
 func (l *CodeLookupSuite) TearDownSuite(c *C) {
 	server.Database.Session.Close()
-	l.DBServer.Wipe()
+	l.DBServer.Stop()
 }
 
 func (l *CodeLookupSuite) TestCodeLookupByName(c *C) {

--- a/controllers/group_totals_test.go
+++ b/controllers/group_totals_test.go
@@ -28,8 +28,7 @@ func (q *QueryTotalsSuite) SetUpSuite(c *C) {
 
 func (q *QueryTotalsSuite) SetUpTest(c *C) {
 	// Setup the database
-	session := q.DBServer.Session()
-	server.Database = session.DB("ie-test")
+	server.Database = q.DBServer.Session().DB("ie-test")
 
 	// Store the bundle
 	bundleFile, err := os.Open("../fixtures/sample-group-data-bundle.json")

--- a/controllers/notification_count_test.go
+++ b/controllers/notification_count_test.go
@@ -33,18 +33,17 @@ func (n *NotificationCountSuite) SetUpSuite(c *C) {
 }
 
 func (n *NotificationCountSuite) SetUpTest(c *C) {
-	session := n.DBServer.Session()
-	server.Database = session.DB("ie-test")
-	n.NotificationCollection = session.DB("ie-test").C("communicationrequests")
-}
-
-func (n *NotificationCountSuite) TearDownSuite(c *C) {
-	n.DBServer.Stop()
+	server.Database = n.DBServer.Session().DB("ie-test")
+	n.NotificationCollection = server.Database.C("communicationrequests")
 }
 
 func (n *NotificationCountSuite) TearDownTest(c *C) {
 	server.Database.Session.Close()
 	n.DBServer.Wipe()
+}
+
+func (n *NotificationCountSuite) TearDownSuite(c *C) {
+	n.DBServer.Stop()
 }
 
 func (n *NotificationCountSuite) TestEmptyNotificationCount(c *C) {

--- a/middleware/notification_handler_test.go
+++ b/middleware/notification_handler_test.go
@@ -43,9 +43,8 @@ func (n *NotificationHandlerSuite) SetUpSuite(c *C) {
 }
 
 func (n *NotificationHandlerSuite) SetUpTest(c *C) {
-	session := n.DBServer.Session()
-	server.Database = session.DB("ie-test")
-	n.NotificationCollection = session.DB("ie-test").C("communicationrequests")
+	server.Database = n.DBServer.Session().DB("ie-test")
+	n.NotificationCollection = n.DBServer.Session().DB("ie-test").C("communicationrequests")
 }
 
 func (n *NotificationHandlerSuite) TearDownTest(c *C) {

--- a/subscription/notifier_test.go
+++ b/subscription/notifier_test.go
@@ -38,8 +38,7 @@ func (r *NotifierSuite) SetUpSuite(c *C) {
 }
 
 func (r *NotifierSuite) SetUpTest(c *C) {
-	session := r.DBServer.Session()
-	server.Database = session.DB("ie-test")
+	server.Database = r.DBServer.Session().DB("ie-test")
 }
 
 func (r *NotifierSuite) TearDownTest(c *C) {
@@ -48,6 +47,7 @@ func (r *NotifierSuite) TearDownTest(c *C) {
 }
 
 func (r *NotifierSuite) TearDownSuite(c *C) {
+	r.DBServer.Stop()
 	r.Server.Close()
 }
 

--- a/subscription/resource_watch_test.go
+++ b/subscription/resource_watch_test.go
@@ -42,8 +42,7 @@ func (r *ResourceWatchSuite) SetUpSuite(c *C) {
 }
 
 func (r *ResourceWatchSuite) SetUpTest(c *C) {
-	session := r.DBServer.Session()
-	server.Database = session.DB("ie-test")
+	server.Database = r.DBServer.Session().DB("ie-test")
 }
 
 func (r *ResourceWatchSuite) TearDownTest(c *C) {
@@ -52,6 +51,7 @@ func (r *ResourceWatchSuite) TearDownTest(c *C) {
 }
 
 func (r *ResourceWatchSuite) TearDownSuite(c *C) {
+	r.DBServer.Stop()
 	r.Server.Close()
 }
 


### PR DESCRIPTION
Trying to make dbtest.DBServer use consistent, in an attempt to squash the intermittent testing errors we see on Travis.  This is mainly re-arranging deck chairs, but I did add a few missing Server.Stop() calls, so we'll see if it makes a difference.
