### PR TITLE
Group Expansion Support

### DIFF
--- a/controllers/routes.go
+++ b/controllers/routes.go
@@ -22,6 +22,8 @@ func RegisterRoutes(s *server.FHIRServer, selfURL, riskServiceEndpoint string) f
 	//s.AddMiddleware("Group", middleware.AuthHandler())
 	//s.AddMiddleware("Patient", middleware.AuthHandler())
 
+	s.AddMiddleware("Patient", PatientListMiddleware())
+
 	s.AddMiddleware("Condition", watch)
 
 	s.AddMiddleware("MedicationStatement", watch)


### PR DESCRIPTION
This is a bit of a hack / quickfix to allow patient queries to specify a special parameter for expanding a group.  With this in place, all patient listing can happen in a uniform way across IE, including support for paging.
