### PR TITLE
Sort CodeLookup search results

### DIFF
--- a/controllers/code_lookup_test.go
+++ b/controllers/code_lookup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/intervention-engine/fhir/models"
 	"github.com/intervention-engine/fhir/server"
 	"github.com/intervention-engine/ie/testutil"
 	"github.com/intervention-engine/ie/utilities"
@@ -27,7 +28,9 @@ func (l *CodeLookupSuite) SetupSuite() {
 	server.Database = l.DB()
 
 	var codes []utilities.CodeEntry
+	var conditions []models.Condition
 	l.InsertFixture("codelookup", "../fixtures/code-lookup.json", &codes)
+	l.InsertFixture("conditions", "../fixtures/code_lookup_suppl.json", &conditions)
 }
 
 func (l *CodeLookupSuite) TearDownSuite() {
@@ -51,6 +54,21 @@ func (l *CodeLookupSuite) TestCodeLookupByName() {
 	require.NoError(err)
 
 	assert.Len(nameResponseCodes, 10)
+	assert.Equal(utilities.CodeEntry{
+		CodeSystem: "ICD-9",
+		Code:       "003.21",
+		Name:       "Salmonella meningitis",
+		Count:      2,
+	}, nameResponseCodes[0])
+	assert.Equal(utilities.CodeEntry{
+		CodeSystem: "ICD-9",
+		Code:       "003.22",
+		Name:       "Salmonella pneumonia",
+		Count:      1,
+	}, nameResponseCodes[1])
+	for i := 2; i < 10; i++ {
+		assert.Equal(0, nameResponseCodes[i].Count)
+	}
 }
 
 func (l *CodeLookupSuite) TestCodeLookupByCode() {

--- a/fixtures/code_lookup_suppl.json
+++ b/fixtures/code_lookup_suppl.json
@@ -1,0 +1,44 @@
+[
+    {
+          "resourceType" : "Condition",
+          "patient": {
+        		"reference": "Patient/1"
+        	},
+          "code" : {
+              "coding" : [
+                  {"system" : "http://hl7.org/fhir/sid/icd-9", "code" : "003.21"}
+              ],
+              "text" : "Salmonella meningitis"
+          },
+          "onsetDateTime": "2015-04-01T00:00:00-04:00",
+          "verificationStatus": "confirmed"
+      },
+      {
+          "resourceType" : "Condition",
+          "patient": {
+        		"reference": "Patient/1"
+        	},
+          "code" : {
+              "coding" : [
+                  {"system" : "http://hl7.org/fhir/sid/icd-9", "code" : "003.22"}
+              ],
+              "text" : "Salmonella pneumonia"
+          },
+          "onsetDateTime": "2015-04-01T00:00:00-04:00",
+          "verificationStatus": "confirmed"
+      },
+      {
+          "resourceType" : "Condition",
+          "patient": {
+        		"reference": "Patient/2"
+        	},
+          "code" : {
+              "coding" : [
+                  {"system" : "http://hl7.org/fhir/sid/icd-9", "code" : "003.21"}
+              ],
+              "text" : "Salmonella meningitis"
+          },
+          "onsetDateTime": "2013-11-15T00:00:00-04:00",
+          "verificationStatus": "confirmed"
+      }
+]

--- a/utilities/code-loader.go
+++ b/utilities/code-loader.go
@@ -19,6 +19,7 @@ type CodeEntry struct {
 	CodeSystem string `bson:"codeSystem",json:"codeSystem"`
 	Code       string `bson:"code",json:"code"`
 	Name       string `bson:"name",json:"name"`
+	Count      int    `bson:"count,omitempty",json:"count,omitempty"`
 }
 
 // LoadICDFromCMS downloads CMS-provided ICD-9 or ICD-10 codes and loads them into the Mongo database


### PR DESCRIPTION
Sort the search results from CodeLookup so that the codes used most often in our database are at the top.  It also returns the actual count as part of the result.

Note that the frontend (UI) seems to be re-sorting these on code, so while the backend is sending them in the correct order, it's not yet showing in the UI.
