### PR TITLE
Fix Encounter-based Huddle Scheduling Bug

### DIFF
--- a/huddles/huddle_scheduler.go
+++ b/huddles/huddle_scheduler.go
@@ -273,7 +273,7 @@ func findEligiblePatientIDsByRecentEncounter(date time.Time, config *HuddleConfi
 						alreadyDiscussed := false
 						for i := range result.Huddles {
 							h := Huddle(result.Huddles[i])
-							if h.ActiveDateTime() != nil && h.ActiveDateTime().Time.After(d) {
+							if h.ActiveDateTime() != nil && !h.ActiveDateTime().Time.Equal(date) && h.ActiveDateTime().Time.After(d) {
 								m := h.FindHuddleMember(result.PatientID)
 								// Only consider it already discussed if the patient was discussed for this same reason
 								alreadyDiscussed = m != nil && m.Reason().MatchesCode(RecentEncounterReason.Coding[0].System, RecentEncounterReason.Coding[0].Code)


### PR DESCRIPTION
Fix bug that caused patients with recent encounter events to be pushed out one huddle every time the scheduler is run (until they go past the lookback interval).

Basically, the problem was that when the code is trying to determine if a patient should be scheduled for a particular huddle date due to an encounter event, it looks to see if that patient has already been scheduled due to that encounter event.  This prevents the patient from being scheduled to multiple huddles for a single event.  What happened was that if the patient was already scheduled for the huddle that was being considered by the algorithm, the algorithm would see that the patient was already scheduled and then NOT put the patient in the list for the date during the rescheduling.  The fix is to check to make sure that you don't look at the huddle that is currently being rescheduled (since you can't really trust it anyway).  Hard to explain -- hope that made sense!

Pivotal: https://www.pivotaltracker.com/story/show/119004879
