### PR TITLE
Support for ORed Codes in Code Filters

### DIFF
--- a/fixtures/sample-group-or-codes.json
+++ b/fixtures/sample-group-or-codes.json
@@ -1,0 +1,31 @@
+{
+  "resourceType": "Group",
+  "type": "person",
+  "actual": false,
+  "name": "Males with major depression",
+  "characteristic": [
+    {
+      "code": {
+        "coding": [{"system": "http://loinc.org", "code": "21840-4"}],
+        "text": "Gender"
+      },
+      "valueCodeableConcept": {
+        "coding": [{"system": "http://hl7.org/fhir/administrative-gender", "code": "male"}]
+      },
+      "exclude": false
+    },
+    {
+      "code": {
+        "coding": [{"system": "http://loinc.org", "code": "11450-4"}],
+        "text": "Condition"
+      },
+      "valueCodeableConcept": {
+        "coding": [
+          {"system": "http://foo", "code": "bar"},
+          {"system": "http://hl7.org/fhir/sid/icd-9", "code": "296.21"}
+        ]
+      },
+      "exclude": false
+    }
+  ]
+}

--- a/groups/group_resolver.go
+++ b/groups/group_resolver.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	fhir "github.com/intervention-engine/fhir/models"
@@ -169,12 +170,12 @@ func LoadCharacteristicInfo(characteristics []fhir.GroupCharacteristicComponent)
 
 		// Condition
 		case characteristic.Code.MatchesCode("http://loinc.org", "11450-4"):
-			c.ConditionQueryValues.Add("code", characteristic.ValueCodeableConcept.Coding[0].System+"|"+characteristic.ValueCodeableConcept.Coding[0].Code)
+			c.ConditionQueryValues.Add("code", codeableConceptQueryValues(characteristic.ValueCodeableConcept))
 			c.HasConditionCharacteristics = true
 
 		// Encounter
 		case characteristic.Code.MatchesCode("http://loinc.org", "46240-8"):
-			c.EncounterQueryValues.Add("type", characteristic.ValueCodeableConcept.Coding[0].System+"|"+characteristic.ValueCodeableConcept.Coding[0].Code)
+			c.EncounterQueryValues.Add("type", codeableConceptQueryValues(characteristic.ValueCodeableConcept))
 			c.HasEncounterCharacteristics = true
 
 		// Unknown
@@ -183,4 +184,12 @@ func LoadCharacteristicInfo(characteristics []fhir.GroupCharacteristicComponent)
 		}
 	}
 	return c, nil
+}
+
+func codeableConceptQueryValues(cc *fhir.CodeableConcept) string {
+	values := make([]string, len(cc.Coding))
+	for i := range cc.Coding {
+		values[i] = cc.Coding[i].System + "|" + cc.Coding[i].Code
+	}
+	return strings.Join(values, ",")
 }

--- a/groups/instacount_test.go
+++ b/groups/instacount_test.go
@@ -94,3 +94,26 @@ func (suite *InstacountSuite) TestInstaCountAllHandlerWithRefutedCondition() {
 	assert.Equal(0, counts["conditions"])
 	assert.Equal(0, counts["encounters"])
 }
+
+func (suite *InstacountSuite) TestInstaCountAllHandlerWithOredCodes() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	handler := InstaCountAllHandler
+	groupFile, _ := os.Open("../fixtures/sample-group-or-codes.json")
+
+	ctx, w, _ := gin.CreateTestContext()
+	ctx.Request, _ = http.NewRequest("POST", "/InstaCountAll", groupFile)
+	ctx.Request.Header.Add("Content-Type", "application/json")
+	handler(ctx)
+	require.Equal(http.StatusOK, w.Code)
+
+	counts := make(map[string]int)
+	err := json.NewDecoder(w.Body).Decode(&counts)
+	require.NoError(err)
+
+	//TODO: These tests should be made more robust once we have better fixtures and test helpers
+	assert.Equal(1, counts["patients"])
+	assert.Equal(1, counts["conditions"])
+	assert.Equal(1, counts["encounters"])
+}


### PR DESCRIPTION
Add support for filter group characteristics that have multiple codings in a codeableconcept.  These multiple codings should be represented in the query as an OR of the values.
