### PR TITLE
Docker Compose v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,12 @@ services:
     depends_on:
       - mongodb
     environment:
-      - MONGO_PORT_27017_TCP_ADDR=mongodb
-      - MULTIFACTORRISKSERVICE_PORT_9000_TCP_ADDR=multifactorriskservice
+      # The values below should not be modified under normal circumstances
+      - HUDDLE_CONFIGS=./configs/multifactor_huddle_config.json
+      - MONGO_URL=mongodb://mongodb:27017
+      - RISK_SERVICE_URL=http://multifactorriskservice:9000
       - GIN_MODE=release
-    command: ./server -huddle ./configs/multifactor_huddle_config.json
+    command: ./server -loadCodes
   endpoint:
     build: ../ie-ccda-endpoint
     ports:
@@ -18,8 +20,8 @@ services:
     depends_on:
       - ie
     environment:
-      - IE_PORT_3001_TCP_ADDR=ie
-      - IE_PORT_3001_TCP_PORT=3001
+      # The value below should not be modified under normal circumstances
+      - FHIR_URL=http://ie:3001
   mongodb:
     image: mongo
     volumes:
@@ -34,9 +36,16 @@ services:
       - ie
       - mongodb
     environment:
-      - MONGO_PORT_27017_TCP_ADDR=mongodb
-    command: ./multifactorriskservice -redcap https://your_redcap_server/redcap/api -token your_redcap_api_token -fhir http://ie:3001 -useStudyID
-    #command: ./mock -fhir http://ie:3001 -gen # for testing only!
+      # REDCAP_URL and REDCAP_TOKEN must be set to valid values before running!
+      - REDCAP_URL=http://myredcapserver/redcap/api
+      - REDCAP_TOKEN=MYREDCAPTOKEN
+      # The values below should not be modified under normal circumstances
+      - FHIR_URL=http://ie:3001
+      - MONGO_URL=mongodb://mongodb:27017
+      - HTTP_HOST_AND_PORT=multifactorriskservice:9000
+      - GIN_MODE=release
+    command: ./multifactorriskservice
+    # command: ./mock -gen # for testing only!
   nginx:
     build: ../nginx
     ports:
@@ -45,6 +54,6 @@ services:
       - ie
       - multifactorriskservice
     environment:
-      - IE_PORT_3001_TCP_ADDR=ie
-      - IE_PORT_3001_TCP_PORT=3001
-    command: /bin/bash -c "envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf '$$IE_PORT_3001_TCP_ADDR:$$IE_PORT_3001_TCP_PORT' && nginx -g 'daemon off;'"
+      # The value below should not be modified under normal circumstances
+      - IE_URL=http://ie:3001
+    command: /bin/bash -c "envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf '$$IE_URL' && nginx -g 'daemon off;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,50 @@
-ie:
-  build: .
-  ports:
-    - "3001"
-  links:
-    - mongodb:mongo
-  command: ./server -huddle ./configs/multifactor_huddle_config.json
-endpoint:
-  build: ../ie-ccda-endpoint
-  ports:
-    - "3000:3000"
-  links:
-    - ie
-mongodb:
-  image: mongo
-  volumes:
-    - /data/db:/data/db
-  ports:
-    - "27017"
-multifactorriskservice:
-  build: ../multifactorriskservice
-  ports:
-    - "9000"
-  links:
-    - mongodb:mongo
-    - ie
-  command: ./multifactorriskservice -redcap https://your_redcap_server/redcap/api -token your_redcap_api_token -fhir http://ie:3001 -useStudyID
-nginx:
-  build: ../nginx
-  ports:
-    - "443:443"
-  links:
-    - ie
-  command: /bin/bash -c "envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf '$$IE_PORT_3001_TCP_ADDR:$$IE_PORT_3001_TCP_PORT' && nginx -g 'daemon off;'"
+version: '2'
+services:
+  ie:
+    build: .
+    ports:
+      - "3001"
+    depends_on:
+      - mongodb
+    environment:
+      - MONGO_PORT_27017_TCP_ADDR=mongodb
+      - MULTIFACTORRISKSERVICE_PORT_9000_TCP_ADDR=multifactorriskservice
+      - GIN_MODE=release
+    command: ./server -huddle ./configs/multifactor_huddle_config.json
+  endpoint:
+    build: ../ie-ccda-endpoint
+    ports:
+      - "3000:3000"
+    depends_on:
+      - ie
+    environment:
+      - IE_PORT_3001_TCP_ADDR=ie
+      - IE_PORT_3001_TCP_PORT=3001
+  mongodb:
+    image: mongo
+    volumes:
+      - /data/db:/data/db
+    ports:
+      - "27017"
+  multifactorriskservice:
+    build: ../multifactorriskservice
+    ports:
+      - "9000"
+    depends_on:
+      - ie
+      - mongodb
+    environment:
+      - MONGO_PORT_27017_TCP_ADDR=mongodb
+    command: ./multifactorriskservice -redcap https://your_redcap_server/redcap/api -token your_redcap_api_token -fhir http://ie:3001 -useStudyID
+    #command: ./mock -fhir http://ie:3001 -gen # for testing only!
+  nginx:
+    build: ../nginx
+    ports:
+      - "443:443"
+    depends_on:
+      - ie
+      - multifactorriskservice
+    environment:
+      - IE_PORT_3001_TCP_ADDR=ie
+      - IE_PORT_3001_TCP_PORT=3001
+    command: /bin/bash -c "envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf '$$IE_PORT_3001_TCP_ADDR:$$IE_PORT_3001_TCP_PORT' && nginx -g 'daemon off;'"

--- a/docs/docker-linux.md
+++ b/docs/docker-linux.md
@@ -68,26 +68,31 @@ Configure docker-compose.yml
 ============================
 Docker-compose is part of the Docker Toolbox which allows the orchestration of multiple containers, allowing the linking of containers and definition of which ports each container exposes and which ports those are mapped to on the Docker host. Docker-compose is configured in the appropriately named docker-compose.yml file. This file currently exists in the *ie* repository.
 
-The top level of the YAML in the docker-compose.yml defines each container to be built. The second level tags of the YAML define specific configuration options for specific containers. The only field that needs to be configured before deployment is the `build` field. This field specifies the local directory in which to find the `Dockerfile` with which to build its parent container.
+The `services` section of the YAML in the docker-compose.yml defines each container to be built. The tags under each container of the YAML define specific configuration options for specific containers. The `build` field within each container may need to be configured before deployment. This field specifies the local directory in which to find the `Dockerfile` with which to build its parent container.
 
 Since our instructions for cloning the Intervention Engine repositories specify to clone some repositories into the $GOPATH and some repositories to your preferred development location, you must set the `build` fields to point to each repository's local directory. For example, if you cloned the *ie-ccda-endpoint* repository to `~/development/intervention-engine/ie-ccda-endpoint`, the `endpoint` section of your docker-compose.yml should look as follows:
 
 ```
-endpoint:
-  build: ~/development/intervention-engine/ie-ccda-endpoint
-  ports:
-    - "3000:3000"
-  links:
-    - ie
-
+  endpoint:
+    build: ~/development/intervention-engine/ie-ccda-endpoint
+    ports:
+      - "3000:3000"
+    depends_on:
+      - ie
+    environment:
+      # The value below should not be modified under normal circumstances
+      - FHIR_URL=http://ie:3001
 ```
 
-You must configure *all* of the `build` fields to point to each repositories local directory.
+You must configure *all* of the `build` fields to point to each repository's local directory.
 
-In addition, you must configure the multifactorriskservice to correctly point to your REDCap installation and contain your REDCap API token.  To do this, edit the values after `-redcap` and `-token` in the `command` entry of the `multifactorriskservice`:
+In addition, you must configure the multifactorriskservice to correctly point to your REDCap installation and contain your REDCap API token.  To do this, edit the `REDCAP_URL` and `REDCAP_TOKEN` values in the `environment` section of the `multifactorriskservice`:
 
 ```
-  command: /go/src/github.com/intervention-engine/multifactorriskservice/multifactorriskservice -redcap https://your_redcap_server/redcap/api -token your_redcap_api_token -fhir http://ie:3001
+    environment:
+      # REDCAP_URL and REDCAP_TOKEN must be set to valid values before running!
+      - REDCAP_URL=http://myredcapserver/redcap/api
+      - REDCAP_TOKEN=MYREDCAPTOKEN
 ```
 
 Create or Configure SSL Certificates and Keys

--- a/docs/docker-mac.md
+++ b/docs/docker-mac.md
@@ -113,26 +113,31 @@ Configure docker-compose.yml
 ============================
 Docker-compose is part of the Docker Toolbox which allows the orchestration of multiple containers, allowing the linking of containers and definition of which ports each container exposes and which ports those are mapped to on the Docker host. Docker-compose is configured in the appropriately named docker-compose.yml file. This file currently exists in the *ie* repository.
 
-The top level of the YAML in the docker-compose.yml defines each container to be built. The second level tags of the YAML define specific configuration options for specific containers. The only field that needs to be configured before deployment is the `build` field. This field specifies the local directory in which to find the `Dockerfile` with which to build its parent container.
+The `services` section of the YAML in the docker-compose.yml defines each container to be built. The tags under each container of the YAML define specific configuration options for specific containers. The `build` field within each container may need to be configured before deployment. This field specifies the local directory in which to find the `Dockerfile` with which to build its parent container.
 
 Since our instructions for cloning the Intervention Engine repositories specify to clone some repositories into the $GOPATH and some repositories to your preferred development location, you must set the `build` fields to point to each repository's local directory. For example, if you cloned the *ie-ccda-endpoint* repository to `~/development/intervention-engine/ie-ccda-endpoint`, the `endpoint` section of your docker-compose.yml should look as follows:
 
 ```
-endpoint:
-  build: ~/development/intervention-engine/ie-ccda-endpoint
-  ports:
-    - "3000:3000"
-  links:
-    - ie
-
+  endpoint:
+    build: ~/development/intervention-engine/ie-ccda-endpoint
+    ports:
+      - "3000:3000"
+    depends_on:
+      - ie
+    environment:
+      # The value below should not be modified under normal circumstances
+      - FHIR_URL=http://ie:3001
 ```
 
-You must configure *all* of the `build` fields to point to each repositories local directory.
+You must configure *all* of the `build` fields to point to each repository's local directory.
 
-In addition, you must configure the multifactorriskservice to correctly point to your REDCap installation and contain your REDCap API token.  To do this, edit the values after `-redcap` and `-token` in the `command` entry of the `multifactorriskservice`:
+In addition, you must configure the multifactorriskservice to correctly point to your REDCap installation and contain your REDCap API token.  To do this, edit the `REDCAP_URL` and `REDCAP_TOKEN` values in the `environment` section of the `multifactorriskservice`:
 
 ```
-  command: /go/src/github.com/intervention-engine/multifactorriskservice/multifactorriskservice -redcap https://your_redcap_server/redcap/api -token your_redcap_api_token -fhir http://ie:3001
+    environment:
+      # REDCAP_URL and REDCAP_TOKEN must be set to valid values before running!
+      - REDCAP_URL=http://myredcapserver/redcap/api
+      - REDCAP_TOKEN=MYREDCAPTOKEN
 ```
 
 Create or Configure SSL Certificates and Keys

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/intervention-engine/fhir/server"
@@ -34,30 +35,31 @@ func init() {
 }
 
 func main() {
-	// Check for a linked MongoDB container if we are running in Docker
-	mongoHost := os.Getenv("MONGO_PORT_27017_TCP_ADDR")
-	if mongoHost == "" {
-		mongoHost = "localhost"
-	}
-
 	codeLookupFlag := flag.Bool("loadCodes", false, "flag to enable download of icd-9 and icd-10 code lookup")
 	icd9URL := flag.String("icd9URL", "https://www.cms.gov/Medicare/Coding/ICD9ProviderDiagnosticCodes/Downloads/ICD-9-CM-v32-master-descriptions.zip", "url for icd-9 code definition zip")
 	icd10URL := flag.String("icd10URL", "https://www.cms.gov/Medicare/Coding/ICD10/Downloads/2016-Code-Descriptions-in-Tabular-Order.zip", "url for icd-10 code definition zip")
 	subscriptionFlag := flag.Bool("subscriptions", false, "enables limited support for resource subscriptions (default: false)")
 	reqLog := flag.Bool("reqlog", false, "Enables request logging -- do NOT use in production")
-
 	flag.Parse()
 
-	if *codeLookupFlag {
-		utilities.LoadICDFromCMS(mongoHost, *icd9URL, "ICD-9")
-		utilities.LoadICDFromCMS(mongoHost, *icd10URL, "ICD-10")
+	mongoURL := os.Getenv("MONGO_URL")
+	if mongoURL == "" {
+		mongoURL = "mongodb://localhost:2017"
 	}
 
-	riskServiceEndpoint := os.Getenv("MULTIFACTORRISKSERVICE_PORT_9000_TCP_ADDR")
-	if riskServiceEndpoint == "" {
-		riskServiceEndpoint = "http://localhost:9000"
-	} else {
-		riskServiceEndpoint = "http://" + riskServiceEndpoint + ":9000"
+	riskServiceURL := os.Getenv("RISK_SERVICE_URL")
+	if riskServiceURL == "" {
+		riskServiceURL = "http://localhost:9000"
+	}
+
+	huddleConfigs := huddleFlag
+	if len(huddleConfigs) == 0 && os.Getenv("HUDDLE_CONFIGS") != "" {
+		huddleConfigs = huddleSlice(strings.Split(os.Getenv("HUDDLE_CONFIGS"), ","))
+	}
+
+	if *codeLookupFlag {
+		utilities.LoadICDFromCMS(mongoURL, *icd9URL, "ICD-9")
+		utilities.LoadICDFromCMS(mongoURL, *icd10URL, "ICD-10")
 	}
 
 	var ip net.IP
@@ -78,7 +80,7 @@ func main() {
 		}
 	}
 
-	s := server.NewServer(mongoHost)
+	s := server.NewServer(mongoURL)
 
 	if *reqLog {
 		s.Engine.Use(server.RequestLoggerHandler)
@@ -88,7 +90,7 @@ func main() {
 	// to take out globals (and other stuff), this should be rethought.
 	c := cron.New()
 	huddleController := new(huddles.HuddleSchedulerController)
-	for _, huddlePath := range huddleFlag {
+	for _, huddlePath := range huddleConfigs {
 		data, err := ioutil.ReadFile(huddlePath)
 		if err != nil {
 			panic(err)
@@ -125,12 +127,12 @@ func main() {
 	}
 	s.Engine.GET("/ScheduleHuddles", huddleController.ScheduleHandler)
 
-	if len(huddleFlag) > 0 {
+	if len(huddleConfigs) > 0 {
 		c.Start()
 		defer c.Stop()
 	}
 
-	closer := controllers.RegisterRoutes(s, selfURL, riskServiceEndpoint, *subscriptionFlag)
+	closer := controllers.RegisterRoutes(s, selfURL, riskServiceURL, *subscriptionFlag)
 	defer closer()
 
 	s.Run(server.Config{

--- a/server.go
+++ b/server.go
@@ -53,7 +53,7 @@ func main() {
 		utilities.LoadICDFromCMS(mongoHost, *icd10URL, "ICD-10")
 	}
 
-	riskServiceEndpoint := os.Getenv("RISKSERVICE_PORT_9000_TCP_ADDR")
+	riskServiceEndpoint := os.Getenv("MULTIFACTORRISKSERVICE_PORT_9000_TCP_ADDR")
 	if riskServiceEndpoint == "" {
 		riskServiceEndpoint = "http://localhost:9000"
 	} else {


### PR DESCRIPTION
Upgrade to Docker Compose v2.  This gives us several new features, the most important of which is the availability of a default network to connect all of the containers.  Moving to v2, however, removes support for the automatically exported environment variables, so I've also taken the opportunity to clean up the use of environment variables to provide a friendlier approach to deployment.

This fix addresses issue IE-32.  In addition, it relies on the following PRs as well:
- https://github.com/intervention-engine/nginx/pull/4
- https://github.com/intervention-engine/ie-ccda-endpoint/pull/5
- https://github.com/intervention-engine/multifactorriskservice/pull/3
