### PR TITLE
Huddle Roll Over

### DIFF
--- a/configs/multifactor_huddle_config.json
+++ b/configs/multifactor_huddle_config.json
@@ -65,6 +65,6 @@
       }
     ]
   },
-  "rollOverDelayInDays": "3",
+  "rollOverDelayInDays": 3,
   "schedulerCronSpec": "0 0 0 * * *"
 }

--- a/configs/multifactor_huddle_config.json
+++ b/configs/multifactor_huddle_config.json
@@ -65,5 +65,6 @@
       }
     ]
   },
+  "rollOverDelayInDays": "3",
   "schedulerCronSpec": "0 0 0 * * *"
 }

--- a/configs/simple_huddle_config.json
+++ b/configs/simple_huddle_config.json
@@ -24,5 +24,6 @@
       }
     ]
   },
+  "rollOverDelayInDays": 3,
   "schedulerCronSpec": "0 0 0 * * *"
 }

--- a/fixtures/huddle_config.json
+++ b/fixtures/huddle_config.json
@@ -60,5 +60,6 @@
       }
     ]
   },
+  "rollOverDelayInDays": 3,
   "schedulerCronSpec": "@midnight"
 }

--- a/fixtures/huddle_config_bare.json
+++ b/fixtures/huddle_config_bare.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bare Huddle",
+  "leaderID": "1",
+  "days": [1],
+  "lookAhead": 4,
+  "schedulerCronSpec": "@midnight"
+}

--- a/huddles/huddle.go
+++ b/huddles/huddle.go
@@ -51,6 +51,14 @@ func (h *Huddle) FindHuddleMember(patientID string) *HuddleMember {
 // HuddleMember provides convenient functions on a GroupMemberComponent to get access to extended huddle data fields
 type HuddleMember models.GroupMemberComponent
 
+// ID returns the members ID
+func (h *HuddleMember) ID() string {
+	if h.Entity == nil {
+		return ""
+	}
+	return h.Entity.ReferencedID
+}
+
 // Reason returns the reason the member was added to the huddle (or nil if the reason isn't set)
 func (h *HuddleMember) Reason() *models.CodeableConcept {
 	reason := findExtension(h.Extension, "http://interventionengine.org/fhir/extension/group/member/reason")
@@ -58,6 +66,30 @@ func (h *HuddleMember) Reason() *models.CodeableConcept {
 		return reason.ValueCodeableConcept
 	}
 	return nil
+}
+
+// ReasonIsManuallyAdded indicates if the member reason is due to the patient being manually added to the huddle
+func (h *HuddleMember) ReasonIsManuallyAdded() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "MANUAL_ADDITION")
+}
+
+// ReasonIsRecentEncounter indicates if the member reason is due to a recent significant encounter
+func (h *HuddleMember) ReasonIsRecentEncounter() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RECENT_ENCOUNTER")
+}
+
+// ReasonIsRiskScore indicates if the member reason is due to the patient's current risk score
+func (h *HuddleMember) ReasonIsRiskScore() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RISK_SCORE")
+}
+
+// ReasonIsRollOver indicates if the member reason is due to roll over from a previous huddle
+func (h *HuddleMember) ReasonIsRollOver() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "ROLLOVER")
 }
 
 // Reviewed returns the date that the member was reviewed for this huddle (or nil if they haven't been reviewed)

--- a/huddles/huddle_config.go
+++ b/huddles/huddle_config.go
@@ -10,17 +10,22 @@ import (
 // is expected to correspond to a Practitioner.  Days refers to the days of the week on which the huddle meets.
 // LookAhead determines how many huddles should be scheduled into the future.  The further out, the more time
 // it takes to plan them and the less certain they are (since any changes ripple out into the future). RiskConfig
-// specifies how risk scores are converted to huddle frequencies.  SchedulerCronSpec indicates when the auto
-// scheduler should be run (for example, nightly) and follows the cron expression format defined by
-// https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format
+// specifies how risk scores are converted to huddle frequencies.  RollOverDelayInDays indicates when patients should
+// be rolled over to the next huddle if they weren't discussed.  1 means they will be rolled over to the next huddle
+// the day after their original huddle (2 means they will be rolled over 2 days after their huddle).  If
+// RollOverDelayInDays isn't specified in the config, or is less than 1, patients are never rolled over to the next
+// huddle.  SchedulerCronSpec indicates when the auto scheduler should be run (for example, nightly) and follows the
+// cron expression format defined/ by https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format.  If
+// SchedulerCronSpec is less frequent than daily, RollOverDelayInDays may not work correctly.
 type HuddleConfig struct {
-	Name              string
-	LeaderID          string
-	Days              []time.Weekday
-	LookAhead         int
-	RiskConfig        *ScheduleByRiskConfig
-	EventConfig       *ScheduleByEventConfig
-	SchedulerCronSpec string
+	Name                string
+	LeaderID            string
+	Days                []time.Weekday
+	LookAhead           int
+	RiskConfig          *ScheduleByRiskConfig
+	EventConfig         *ScheduleByEventConfig
+	RollOverDelayInDays int
+	SchedulerCronSpec   string
 }
 
 // IsHuddleDay returns true if the passed in date occurs on one of configured huddle weekdays.

--- a/huddles/huddle_config_test.go
+++ b/huddles/huddle_config_test.go
@@ -19,6 +19,7 @@ func TestHuddleConfigSuite(t *testing.T) {
 type HuddleConfigSuite struct {
 	suite.Suite
 	SimpleConfig *HuddleConfig
+	BareConfig   *HuddleConfig
 }
 
 func (suite *HuddleConfigSuite) SetupSuite() {
@@ -28,6 +29,12 @@ func (suite *HuddleConfigSuite) SetupSuite() {
 	require.NoError(err)
 	suite.SimpleConfig = new(HuddleConfig)
 	err = json.Unmarshal(data, suite.SimpleConfig)
+	require.NoError(err)
+
+	data, err = ioutil.ReadFile("../fixtures/huddle_config_bare.json")
+	require.NoError(err)
+	suite.BareConfig = new(HuddleConfig)
+	err = json.Unmarshal(data, suite.BareConfig)
 	require.NoError(err)
 }
 
@@ -101,6 +108,22 @@ func (suite *HuddleConfigSuite) TestLoadHuddleFromJSON() {
 			},
 		},
 	}, config.EventConfig.EncounterConfigs)
+	assert.NotNil(config.RollOverDelayInDays)
+	assert.Equal(3, config.RollOverDelayInDays)
+	assert.Equal(config.SchedulerCronSpec, "@midnight")
+}
+
+func (suite *HuddleConfigSuite) TestLoadBareHuddleFromJSON() {
+	assert := suite.Assert()
+
+	config := suite.BareConfig
+	assert.Equal("Bare Huddle", config.Name)
+	assert.Equal("1", config.LeaderID)
+	assert.Equal([]time.Weekday{time.Monday}, config.Days)
+	assert.Equal(4, config.LookAhead)
+	assert.Nil(config.RiskConfig)
+	assert.Nil(config.EventConfig)
+	assert.Equal(0, config.RollOverDelayInDays)
 	assert.Equal(config.SchedulerCronSpec, "@midnight")
 }
 

--- a/huddles/huddle_test.go
+++ b/huddles/huddle_test.go
@@ -75,11 +75,11 @@ func (suite *HuddleSuite) TestHuddleMembers() {
 
 	m := suite.Huddle.HuddleMembers()
 	require.Len(m, 5)
-	assert.Equal("1111111111111111111", m[0].Entity.ReferencedID)
-	assert.Equal("2222222222222222222", m[1].Entity.ReferencedID)
-	assert.Equal("3333333333333333333", m[2].Entity.ReferencedID)
-	assert.Equal("4444444444444444444", m[3].Entity.ReferencedID)
-	assert.Equal("5555555555555555555", m[4].Entity.ReferencedID)
+	assert.Equal("1111111111111111111", m[0].ID())
+	assert.Equal("2222222222222222222", m[1].ID())
+	assert.Equal("3333333333333333333", m[2].ID())
+	assert.Equal("4444444444444444444", m[3].ID())
+	assert.Equal("5555555555555555555", m[4].ID())
 
 	// Clear the members and check
 	suite.Huddle.Member = []models.GroupMemberComponent{}
@@ -92,7 +92,7 @@ func (suite *HuddleSuite) TestFindHuddleMember() {
 
 	m := suite.Huddle.FindHuddleMember("4444444444444444444")
 	require.NotNil(m)
-	assert.Equal("4444444444444444444", m.Entity.ReferencedID)
+	assert.Equal("4444444444444444444", m.ID())
 
 	// Try to find one that does not exist
 	m = suite.Huddle.FindHuddleMember("6666666666666666666")


### PR DESCRIPTION
Huddles can be configured to roll over patients who weren't reviewed in a past huddle.  The configuration allows for a set number of days to wait before rolling over the patients (in case the huddle meets a day late, etc).

During huddle scheduling, we look back that number of days to see if there was a huddle.  If there was, we then loop through the members to see if any do not have the review date set.  If we find any with no review date, we reschedule them to the next huddle.

If they would have been in the next huddle anyway (due to manual scheduling, risk score, or recent encounter), then keep the original reason (rather than rollover reason).

This feature should only be used if teams are consistent about marking patients reviewed -- because otherwise huddles will just keep piling up.
