### PR TITLE
Docker container should wait for mongodb port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,10 @@ RUN go build server.go
 
 # Document that the service listens on port 3001.
 EXPOSE 3001
+
+# Install Dockerize to get support for waiting on another container's port to be available.
+# This is needed here so docker-compose can be configured to wait on the mongodb port to be available.
+RUN apt-get update && apt-get install -y wget
+ENV DOCKERIZE_VERSION v0.2.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MONGO_URL=mongodb://mongodb:27017
       - RISK_SERVICE_URL=http://multifactorriskservice:9000
       - GIN_MODE=release
-    command: ./server -loadCodes
+    command: dockerize -wait tcp://mongodb:27017 -timeout 300s ./server -loadCodes
   endpoint:
     build: ../ie-ccda-endpoint
     ports:
@@ -44,8 +44,8 @@ services:
       - MONGO_URL=mongodb://mongodb:27017
       - HTTP_HOST_AND_PORT=multifactorriskservice:9000
       - GIN_MODE=release
-    command: ./multifactorriskservice
-    # command: ./mock -gen # for testing only!
+    command: dockerize -wait tcp://mongodb:27017 -timeout 300s ./multifactorriskservice
+    # command: dockerize -wait tcp://mongodb:27017 -timeout 300s ./mock # for testing only!
   integrator:
     build: ../integrator
     depends_on:
@@ -70,7 +70,7 @@ services:
       - INGEST_URL=http://endpoint:3000/ccda
       - MONGO_URL=mongodb://mongodb:27017
       #- COPY_DIR=/data/integrator/ccda # for debugging only
-    command: dockerize -wait http://endpoint:3000 -timeout 300s ./integrator
+    command: dockerize -wait http://endpoint:3000 -wait tcp://mongodb:27017 -timeout 300s ./integrator
   nginx:
     build: ../nginx
     ports:


### PR DESCRIPTION
Add dockerize tool to docker image and adjust docker-compose to use it to wait for the mongodb port before starting the ie or multifactorriskservice containers.
