### PR TITLE
Huddle scheduling refactored

### DIFF
--- a/config/multifactor_huddle_config.json
+++ b/config/multifactor_huddle_config.json
@@ -2,7 +2,7 @@
   "name": "Interdisciplinary Huddle",
   "leaderID": "1",
   "days": [1],
-  "lookAhead": 40,
+  "lookAhead": 16,
   "riskConfig": {
     "riskMethod": {"system": "http://interventionengine.org/risk-assessments", "code": "MultiFactor"},
     "frequencyConfigs": [

--- a/config/multifactor_huddle_config.json
+++ b/config/multifactor_huddle_config.json
@@ -2,30 +2,34 @@
   "name": "Interdisciplinary Huddle",
   "leaderID": "1",
   "days": [1],
-  "lookAhead": 14,
+  "lookAhead": 40,
   "riskConfig": {
     "riskMethod": {"system": "http://interventionengine.org/risk-assessments", "code": "MultiFactor"},
     "frequencyConfigs": [
       {
         "minScore": 4,
         "maxScore": 4,
-        "minDaysBetweenHuddles": 5,
-        "maxDaysBetweenHuddles": 7
+        "idealFrequency": 1,
+        "minFrequency": 1,
+        "maxFrequency": 1
       }, {
         "minScore": 3,
         "maxScore": 3,
-        "minDaysBetweenHuddles": 15,
-        "maxDaysBetweenHuddles": 21
+        "idealFrequency": 3,
+        "minFrequency": 2,
+        "maxFrequency": 4
       }, {
         "minScore": 2,
         "maxScore": 2,
-        "minDaysBetweenHuddles": 36,
-        "maxDaysBetweenHuddles": 42
+        "idealFrequency": 6,
+        "minFrequency": 4,
+        "maxFrequency": 8
       }, {
         "minScore": 1,
         "maxScore": 1,
-        "minDaysBetweenHuddles": 85,
-        "maxDaysBetweenHuddles": 91
+        "idealFrequency": 13,
+        "minFrequency": 10,
+        "maxFrequency": 16
       }
     ]
   },

--- a/config/simple_huddle_config.json
+++ b/config/simple_huddle_config.json
@@ -9,18 +9,21 @@
       {
         "minScore": 6,
         "maxScore": 10,
-        "minDaysBetweenHuddles": 5,
-        "maxDaysBetweenHuddles": 7
+        "idealFrequency": 1,
+        "minFrequency": 1,
+        "maxFrequency": 1
       }, {
         "minScore": 4,
         "maxScore": 5,
-        "minDaysBetweenHuddles": 12,
-        "maxDaysBetweenHuddles": 14
+        "idealFrequency": 2,
+        "minFrequency": 1,
+        "maxFrequency": 3
       }, {
         "minScore": 1,
         "maxScore": 3,
-        "minDaysBetweenHuddles": 25,
-        "maxDaysBetweenHuddles": 28
+        "idealFrequency": 4,
+        "minFrequency": 2,
+        "maxFrequency": 6
       }
     ]
   },

--- a/docs/huddle_config.md
+++ b/docs/huddle_config.md
@@ -22,10 +22,10 @@ The following annotated huddle configuration file describes the configurable poi
      you do not wish to use risk scores as a factor for scheduling huddles. */
   "riskConfig": {
     /* RiskMethod needs to correspond to the method code used in the FHIR RiskAssessment resources.  It will be used
-       to lookup the risk scores of patients. */ 
+       to lookup the risk scores of patients. */
     "riskMethod": {"system": "http://interventionengine.org/risk-assessments", "code": "ExampleRisk"},
     /* FrequencyConfigs is a list of configurations indicating the frequency at which patients should be scheduled,
-       based on their risk score.  Usually, the higher the score, the more frequently they should be scheduled. 
+       based on their risk score.  Usually, the higher the score, the more frequently they should be scheduled.
        This example uses a fiction risk scoring algorithm that range from 0 to 20. */
     "frequencyConfigs": [
       /* This config indicates that patients with a risk score of 18-20 should be discussed about once a week. */
@@ -34,33 +34,41 @@ The following annotated huddle configuration file describes the configurable poi
         "minScore": 18,
         /* MaxScore indicates the high (inclusive) value of the risk score indicating this frequency configuration. */
         "maxScore": 20,
-        /* MinDaysBetweenHuddles indicates the smallest number of days that should pass between huddles in which this
-           patient is discussed.  In other words, discuss this patient no more frequently than every 5 days. */
-        "minDaysBetweenHuddles": 5,
-        /* MaxDaysBetweenHuddles indicates the largest number of days that should pass between huddles in which this
-           patient is discussed.  In other words, discuss this patient no less frequently than every 7 days. */
-        "maxDaysBetweenHuddles": 7
+        /* IdealFrequency indicates the ideal huddle frequency for scheduling patients (e.g., every n huddles).
+           The scheduler will attempt to accomplish this frequency if possible. */
+        "idealFrequency": 1,
+        /* MinFrequency indicates the minimum huddle frequency for scheduling patients (e.g., no more frequent than
+           every n huddles). The scheduler may use MinFrequency to help ensure an even distribution of patients
+           across huddles. */
+        "minFrequency": 1,
+        /* MaxFrequency indicates the maximum huddle frequency for scheduling patients (e.g., no less frequent than
+           every n huddles). The scheduler may use MaxFrequency to help ensure an even distribution of patients
+           across huddles. */
+        "maxFrequency": 1
       },
       /* This config indicates that patients with a risk score of 12-17 should be discussed about once every 3 weeks. */
       {
         "minScore": 12,
         "maxScore": 17,
-        "minDaysBetweenHuddles": 15,
-        "maxDaysBetweenHuddles": 21
+        "idealFrequency": 3,
+        "minFrequency": 2,
+        "maxFrequency": 4
       },
       /* This config indicates that patients with a risk score of 5-11 should be discussed about once every 6 weeks. */
       {
         "minScore": 5,
         "maxScore": 11,
-        "minDaysBetweenHuddles": 36,
-        "maxDaysBetweenHuddles": 42
+        "idealFrequency": 6,
+        "minFrequency": 4,
+        "maxFrequency": 8
       },
       /* This config indicates that patients with a risk score of 0-4 should be discussed about once every 13 weeks. */
       {
         "minScore": 0,
         "maxScore": 4,
-        "minDaysBetweenHuddles": 85,
-        "maxDaysBetweenHuddles": 91
+        "idealFrequency": 13,
+        "minFrequency": 9,
+        "maxFrequency": 17
       }
     ]
   },
@@ -118,6 +126,9 @@ The following annotated huddle configuration file describes the configurable poi
       }
     ]
   },
+  /* RollOverDelayInDays indicates how many days to wait before rolling over undiscussed patients to the next huddle.
+     If it is 0 (or less) then rollovers are disabled. */
+  "rollOverDelayInDays": 3,
   /* SchedulerCronSpec indicates when the scheduling algorithm should be run.  The six digits corresond to seconds,
      minutes, hours, day of month, month, day of week.  In the example below, the algorithm is run every day at
      00:00:00.  For more information, see: https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format */

--- a/fixtures/huddle_config.json
+++ b/fixtures/huddle_config.json
@@ -9,18 +9,21 @@
       {
         "minScore": 6,
         "maxScore": 10,
-        "minDaysBetweenHuddles": 5,
-        "maxDaysBetweenHuddles": 7
+        "idealFrequency": 1,
+        "minFrequency": 1,
+        "maxFrequency": 1
       }, {
         "minScore": 4,
         "maxScore": 5,
-        "minDaysBetweenHuddles": 12,
-        "maxDaysBetweenHuddles": 14
+        "idealFrequency": 2,
+        "minFrequency": 1,
+        "maxFrequency": 3
       }, {
         "minScore": 1,
         "maxScore": 3,
-        "minDaysBetweenHuddles": 25,
-        "maxDaysBetweenHuddles": 28
+        "idealFrequency": 4,
+        "minFrequency": 2,
+        "maxFrequency": 6
       }
     ]
   },

--- a/huddles/huddle.go
+++ b/huddles/huddle.go
@@ -1,9 +1,57 @@
 package huddles
 
-import "github.com/intervention-engine/fhir/models"
+import (
+	"fmt"
+	"time"
+
+	"github.com/intervention-engine/fhir/models"
+	"gopkg.in/mgo.v2/bson"
+)
 
 // Huddle provides convenient functions on a Group to get access to extended huddle data fields
 type Huddle models.Group
+
+// NewHuddle constructs a new Huddle using the provided information
+func NewHuddle(name string, leaderID string, date time.Time) *Huddle {
+	tru := true
+	huddle := Huddle(models.Group{
+		DomainResource: models.DomainResource{
+			Resource: models.Resource{
+				Id:           bson.NewObjectId().Hex(),
+				ResourceType: "Group",
+				Meta: &models.Meta{
+					Profile: []string{"http://interventionengine.org/fhir/profile/huddle"},
+				},
+			},
+			Extension: []models.Extension{
+				{
+					Url:           "http://interventionengine.org/fhir/extension/group/activeDateTime",
+					ValueDateTime: &models.FHIRDateTime{Time: date, Precision: models.Precision(models.Date)},
+				},
+				{
+					Url: "http://interventionengine.org/fhir/extension/group/leader",
+					ValueReference: &models.Reference{
+						Reference:    "Practitioner/" + leaderID,
+						ReferencedID: leaderID,
+						Type:         "Practitioner",
+						External:     new(bool),
+					},
+				},
+			},
+		},
+		Type:   "person",
+		Actual: &tru,
+		Code: &models.CodeableConcept{
+			Coding: []models.Coding{
+				{System: "http://interventionengine.org/fhir/cs/huddle", Code: "HUDDLE"},
+			},
+			Text: "Huddle",
+		},
+		Name: name,
+	})
+
+	return &huddle
+}
 
 // IsHuddle checks the Group's code to ensure it has the proper Huddle code
 func (h *Huddle) IsHuddle() bool {
@@ -42,6 +90,87 @@ func (h *Huddle) FindHuddleMember(patientID string) *HuddleMember {
 	for i := range h.Member {
 		if h.Member[i].Entity.ReferencedID == patientID {
 			hm := HuddleMember(h.Member[i])
+			return &hm
+		}
+	}
+	return nil
+}
+
+// AddHuddleMemberDueToRiskScore adds the patient to the huddle using RISK_SCORE as the reason.  If the
+// patient is already in the huddle, nothing will be updated.
+func (h *Huddle) AddHuddleMemberDueToRiskScore(patientID string) {
+	h.addHuddleMember(patientID, &models.CodeableConcept{
+		Coding: []models.Coding{
+			{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "RISK_SCORE"},
+		},
+		Text: "Risk Score Warrants Discussion",
+	})
+}
+
+// AddHuddleMemberDueToRecentEvent adds the patient to the huddle using RECENT_ENCOUNTER event code as the reason.
+// If the patient is already in the huddle, nothing will be updated.
+func (h *Huddle) AddHuddleMemberDueToRecentEvent(patientID string, code EventCode) {
+	h.addHuddleMember(patientID, &models.CodeableConcept{
+		Coding: []models.Coding{
+			{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "RECENT_ENCOUNTER"},
+		},
+		Text: code.Name,
+	})
+}
+
+// AddHuddleMemberDueToRollOver adds the patient to the huddle using the ROLLOVER and previous reason.
+// If the patient is already in the huddle, nothing will be updated.
+func (h *Huddle) AddHuddleMemberDueToRollOver(patientID string, from time.Time, previousReason *models.CodeableConcept) {
+	var reason string
+	if previousReason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "ROLLOVER") {
+		reason = previousReason.Text
+	} else if previousReason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "MANUAL_ADDITION") {
+		reason = fmt.Sprintf("Rolled Over from %s (Manually Added - %s)", from.Format("Jan 2"), previousReason.Text)
+	} else {
+		reason = fmt.Sprintf("Rolled Over from %s (%s)", from.Format("Jan 2"), previousReason.Text)
+	}
+	h.addHuddleMember(patientID, &models.CodeableConcept{
+		Coding: []models.Coding{
+			{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
+		},
+		Text: reason,
+	})
+}
+
+func (h *Huddle) addHuddleMember(patientID string, reason *models.CodeableConcept) {
+	// First look to see if the patient is already in the group, and if so, return
+	if h.FindHuddleMember(patientID) != nil {
+		return
+	}
+
+	// The patient is not yet in the group, so add him/her
+	h.Member = append(h.Member, models.GroupMemberComponent{
+		BackboneElement: models.BackboneElement{
+			Element: models.Element{
+				Extension: []models.Extension{
+					{
+						Url:                  "http://interventionengine.org/fhir/extension/group/member/reason",
+						ValueCodeableConcept: reason,
+					},
+				},
+			},
+		},
+		Entity: &models.Reference{
+			Reference:    "Patient/" + patientID,
+			ReferencedID: patientID,
+			Type:         "Patient",
+			External:     new(bool),
+		},
+	})
+}
+
+// RemoveHuddleMember removes the requested huddle member and returns the removed member.
+// If no matching member is found, it returns nil.
+func (h *Huddle) RemoveHuddleMember(patientID string) *HuddleMember {
+	for i := range h.Member {
+		if h.Member[i].Entity.ReferencedID == patientID {
+			hm := HuddleMember(h.Member[i])
+			h.Member = append(h.Member[:i], h.Member[i+1:]...)
 			return &hm
 		}
 	}

--- a/huddles/huddle.go
+++ b/huddles/huddle.go
@@ -138,9 +138,16 @@ func (h *Huddle) AddHuddleMemberDueToRollOver(patientID string, from time.Time, 
 }
 
 func (h *Huddle) addHuddleMember(patientID string, reason *models.CodeableConcept) {
-	// First look to see if the patient is already in the group, and if so, return
-	if h.FindHuddleMember(patientID) != nil {
-		return
+	// First look to see if the patient is already in the group and act accordingly.
+	existing := h.FindHuddleMember(patientID)
+	if existing != nil {
+		if existing.ReasonIsRollOver() {
+			// We allow overwrites of rollovers, so remove the existing entry and continue
+			h.RemoveHuddleMember(patientID)
+		} else {
+			// We don't allow overwrites of other reasons, so just ignore this request
+			return
+		}
 	}
 
 	// The patient is not yet in the group, so add him/her

--- a/huddles/huddle.go
+++ b/huddles/huddle.go
@@ -184,59 +184,6 @@ func (h *Huddle) RemoveHuddleMember(patientID string) *HuddleMember {
 	return nil
 }
 
-// HuddleMember provides convenient functions on a GroupMemberComponent to get access to extended huddle data fields
-type HuddleMember models.GroupMemberComponent
-
-// ID returns the members ID
-func (h *HuddleMember) ID() string {
-	if h.Entity == nil {
-		return ""
-	}
-	return h.Entity.ReferencedID
-}
-
-// Reason returns the reason the member was added to the huddle (or nil if the reason isn't set)
-func (h *HuddleMember) Reason() *models.CodeableConcept {
-	reason := findExtension(h.Extension, "http://interventionengine.org/fhir/extension/group/member/reason")
-	if reason != nil {
-		return reason.ValueCodeableConcept
-	}
-	return nil
-}
-
-// ReasonIsManuallyAdded indicates if the member reason is due to the patient being manually added to the huddle
-func (h *HuddleMember) ReasonIsManuallyAdded() bool {
-	reason := h.Reason()
-	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "MANUAL_ADDITION")
-}
-
-// ReasonIsRecentEncounter indicates if the member reason is due to a recent significant encounter
-func (h *HuddleMember) ReasonIsRecentEncounter() bool {
-	reason := h.Reason()
-	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RECENT_ENCOUNTER")
-}
-
-// ReasonIsRiskScore indicates if the member reason is due to the patient's current risk score
-func (h *HuddleMember) ReasonIsRiskScore() bool {
-	reason := h.Reason()
-	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RISK_SCORE")
-}
-
-// ReasonIsRollOver indicates if the member reason is due to roll over from a previous huddle
-func (h *HuddleMember) ReasonIsRollOver() bool {
-	reason := h.Reason()
-	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "ROLLOVER")
-}
-
-// Reviewed returns the date that the member was reviewed for this huddle (or nil if they haven't been reviewed)
-func (h *HuddleMember) Reviewed() *models.FHIRDateTime {
-	reviewed := findExtension(h.Extension, "http://interventionengine.org/fhir/extension/group/member/reviewed")
-	if reviewed != nil {
-		return reviewed.ValueDateTime
-	}
-	return nil
-}
-
 func findExtension(ext []models.Extension, extURL string) *models.Extension {
 	for i := range ext {
 		if ext[i].Url == extURL {

--- a/huddles/huddle_config.go
+++ b/huddles/huddle_config.go
@@ -46,10 +46,27 @@ type ScheduleByRiskConfig struct {
 
 // RiskScoreFrequencyConfig represents the relationship between risk scores and frequency of huddle discussion
 type RiskScoreFrequencyConfig struct {
-	MinScore              float64
-	MaxScore              float64
-	MinDaysBetweenHuddles int
-	MaxDaysBetweenHuddles int
+	MinScore       float64
+	MaxScore       float64
+	IdealFrequency int
+	MinFrequency   int
+	MaxFrequency   int
+}
+
+// FindRiskScoreFrequencyConfigByScore finds the proper risk config for a given score
+func (hc *HuddleConfig) FindRiskScoreFrequencyConfigByScore(score float64) *RiskScoreFrequencyConfig {
+	if hc.RiskConfig == nil {
+		return nil
+	}
+
+	for i := range hc.RiskConfig.FrequencyConfigs {
+		fc := hc.RiskConfig.FrequencyConfigs[i]
+		if score >= fc.MinScore && score <= fc.MaxScore {
+			return &fc
+		}
+	}
+
+	return nil
 }
 
 // ScheduleByEventConfig represents how recent events should influence huddle population

--- a/huddles/huddle_config_test.go
+++ b/huddles/huddle_config_test.go
@@ -54,20 +54,23 @@ func (suite *HuddleConfigSuite) TestLoadHuddleFromJSON() {
 	}, config.RiskConfig.RiskMethod)
 	assert.Equal([]RiskScoreFrequencyConfig{
 		{
-			MinScore:              6,
-			MaxScore:              10,
-			MinDaysBetweenHuddles: 5,
-			MaxDaysBetweenHuddles: 7,
+			MinScore:       6,
+			MaxScore:       10,
+			IdealFrequency: 1,
+			MinFrequency:   1,
+			MaxFrequency:   1,
 		}, {
-			MinScore:              4,
-			MaxScore:              5,
-			MinDaysBetweenHuddles: 12,
-			MaxDaysBetweenHuddles: 14,
+			MinScore:       4,
+			MaxScore:       5,
+			IdealFrequency: 2,
+			MinFrequency:   1,
+			MaxFrequency:   3,
 		}, {
-			MinScore:              1,
-			MaxScore:              3,
-			MinDaysBetweenHuddles: 25,
-			MaxDaysBetweenHuddles: 28,
+			MinScore:       1,
+			MaxScore:       3,
+			IdealFrequency: 4,
+			MinFrequency:   2,
+			MaxFrequency:   6,
 		},
 	}, config.RiskConfig.FrequencyConfigs)
 	require.NotNil(config.EventConfig)

--- a/huddles/huddle_controller.go
+++ b/huddles/huddle_controller.go
@@ -1,10 +1,11 @@
 package huddles
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/intervention-engine/fhir/models"
 )
 
 type HuddleSchedulerController struct {
@@ -16,13 +17,16 @@ func (h *HuddleSchedulerController) AddConfig(config *HuddleConfig) {
 }
 
 func (h *HuddleSchedulerController) ScheduleHandler(c *gin.Context) {
-	var scheduledHuddles []*models.Group
+	var scheduledHuddles []*Huddle
 	for i := range h.configs {
-		huddles, err := ScheduleHuddles(&h.configs[i])
+		hs := NewHuddleScheduler(&h.configs[i])
+		start := time.Now()
+		huddles, err := hs.ScheduleHuddles()
 		if err != nil {
 			c.AbortWithError(http.StatusInternalServerError, err)
 			return
 		}
+		fmt.Println(time.Now().Sub(start))
 		scheduledHuddles = append(scheduledHuddles, huddles...)
 	}
 	c.JSON(http.StatusOK, scheduledHuddles)

--- a/huddles/huddle_controller.go
+++ b/huddles/huddle_controller.go
@@ -1,9 +1,7 @@
 package huddles
 
 import (
-	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,13 +18,11 @@ func (h *HuddleSchedulerController) ScheduleHandler(c *gin.Context) {
 	var scheduledHuddles []*Huddle
 	for i := range h.configs {
 		hs := NewHuddleScheduler(&h.configs[i])
-		start := time.Now()
 		huddles, err := hs.ScheduleHuddles()
 		if err != nil {
 			c.AbortWithError(http.StatusInternalServerError, err)
 			return
 		}
-		fmt.Println(time.Now().Sub(start))
 		scheduledHuddles = append(scheduledHuddles, huddles...)
 	}
 	c.JSON(http.StatusOK, scheduledHuddles)

--- a/huddles/huddle_member.go
+++ b/huddles/huddle_member.go
@@ -1,0 +1,56 @@
+package huddles
+
+import "github.com/intervention-engine/fhir/models"
+
+// HuddleMember provides convenient functions on a GroupMemberComponent to get access to extended huddle data fields
+type HuddleMember models.GroupMemberComponent
+
+// ID returns the members ID
+func (h *HuddleMember) ID() string {
+	if h.Entity == nil {
+		return ""
+	}
+	return h.Entity.ReferencedID
+}
+
+// Reason returns the reason the member was added to the huddle (or nil if the reason isn't set)
+func (h *HuddleMember) Reason() *models.CodeableConcept {
+	reason := findExtension(h.Extension, "http://interventionengine.org/fhir/extension/group/member/reason")
+	if reason != nil {
+		return reason.ValueCodeableConcept
+	}
+	return nil
+}
+
+// ReasonIsManuallyAdded indicates if the member reason is due to the patient being manually added to the huddle
+func (h *HuddleMember) ReasonIsManuallyAdded() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "MANUAL_ADDITION")
+}
+
+// ReasonIsRecentEncounter indicates if the member reason is due to a recent significant encounter
+func (h *HuddleMember) ReasonIsRecentEncounter() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RECENT_ENCOUNTER")
+}
+
+// ReasonIsRiskScore indicates if the member reason is due to the patient's current risk score
+func (h *HuddleMember) ReasonIsRiskScore() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "RISK_SCORE")
+}
+
+// ReasonIsRollOver indicates if the member reason is due to roll over from a previous huddle
+func (h *HuddleMember) ReasonIsRollOver() bool {
+	reason := h.Reason()
+	return reason != nil && reason.MatchesCode("http://interventionengine.org/fhir/cs/huddle-member-reason", "ROLLOVER")
+}
+
+// Reviewed returns the date that the member was reviewed for this huddle (or nil if they haven't been reviewed)
+func (h *HuddleMember) Reviewed() *models.FHIRDateTime {
+	reviewed := findExtension(h.Extension, "http://interventionengine.org/fhir/extension/group/member/reviewed")
+	if reviewed != nil {
+		return reviewed.ValueDateTime
+	}
+	return nil
+}

--- a/huddles/huddle_scheduler.go
+++ b/huddles/huddle_scheduler.go
@@ -637,3 +637,31 @@ func getStringDate(huddle *Huddle) string {
 	}
 	return ""
 }
+
+/* FOR DEBUGGING
+func (hs *HuddleScheduler) printPatientInfos() {
+	pIDs := make([]string, 0, len(hs.patientInfos))
+	for _, pInfo := range hs.patientInfos {
+		pIDs = append(pIDs, pInfo.ID)
+	}
+	sort.Strings(pIDs)
+	for _, id := range pIDs {
+		pInfo := hs.patientInfos[id]
+		fmt.Printf("%s [Score: %s, Last: %s, Ideal: %s, Near: %s, Far: %s]\n", pInfo.ID, strF(pInfo.Score), strI(pInfo.LastHuddle), strI(pInfo.NextIdealHuddle), strI(pInfo.NearestAllowedHuddle), strI(pInfo.FurthestAllowedHuddle))
+	}
+}
+
+func strF(f *float64) string {
+	if f == nil {
+		return "?"
+	}
+	return fmt.Sprint(*f)
+}
+
+func strI(i *int) string {
+	if i == nil {
+		return "?"
+	}
+	return fmt.Sprint(*i)
+}
+*/

--- a/huddles/huddle_scheduler.go
+++ b/huddles/huddle_scheduler.go
@@ -3,6 +3,7 @@ package huddles
 import (
 	"fmt"
 	"hash/fnv"
+	"log"
 	"math"
 	"sort"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/intervention-engine/fhir/models"
 	"github.com/intervention-engine/fhir/search"
 	"github.com/intervention-engine/fhir/server"
-	"github.com/labstack/gommon/log"
 )
 
 // HuddleScheduler schedules huddles based on the passed in config.
@@ -90,20 +90,17 @@ func (p *patientInfo) UpdateHuddleTargets(config *HuddleConfig) {
 func (hs *HuddleScheduler) ScheduleHuddles() ([]*Huddle, error) {
 	// First populate the structures we need to do the scheduling
 	if err := hs.populatePatientInfosWithRiskScores(); err != nil {
-		log.Error(err)
 		return nil, err
 	}
 
 	err := hs.populatePatientInfosWithHuddleInfo()
 	if err != nil {
-		log.Error(err)
 		return nil, err
 	}
 
 	// Then create the populated huddles
 	err = hs.createHuddles()
 	if err != nil {
-		log.Error(err)
 		return nil, err
 	}
 
@@ -112,7 +109,7 @@ func (hs *HuddleScheduler) ScheduleHuddles() ([]*Huddle, error) {
 	for i := range hs.Huddles {
 		if _, err := server.Database.C("groups").UpsertId(hs.Huddles[i].Id, hs.Huddles[i]); err != nil {
 			lastErr = err
-			log.Warn("Error storing huddle: %t", err)
+			log.Printf("Error storing huddle: %s\n", err)
 		}
 	}
 

--- a/huddles/huddle_scheduler_test.go
+++ b/huddles/huddle_scheduler_test.go
@@ -46,18 +46,18 @@ func (suite *HuddleSchedulerSuite) TestCreatePopulatedHuddleForNewHuddle() {
 	suite.storePatientAndScores(bsonID(2), 1, 2, 2)   // 02  | never   |                    |
 	suite.storePatientAndScores(bsonID(3), 2, 1, 1)   // 03  | never   |                    | * (see encounters below)
 	suite.storePatientAndScores(bsonID(4), 1, 2, 1)   // 04  | never   |                    |
-	suite.storePatientAndScores(bsonID(5), 2, 3, 2)   // 05  | never   | 7 weeks ago (2/01) |
+	suite.storePatientAndScores(bsonID(5), 2, 3, 2)   // 05  | never   | 5 weeks ago (2/01) |
 	suite.storePatientAndScores(bsonID(6), 1, 2, 3)   // 06  | 4 weeks | 1 week ago  (3/14) | 4/11
-	suite.storePatientAndScores(bsonID(7), 6, 6, 5)   // 07  | 4 weeks | 7 weeks ago (2/01) | 3/21 (overdue)
-	suite.storePatientAndScores(bsonID(8), 5, 5, 4)   // 08  | 4 weeks |                    | 3/21 (overdue)
+	suite.storePatientAndScores(bsonID(7), 6, 6, 5)   // 07  | 4 weeks | 5 weeks ago (2/01) | 3/21 (overdue)
+	suite.storePatientAndScores(bsonID(8), 5, 5, 4)   // 08  | 4 weeks |                    | 4/11 (at latest)
 	suite.storePatientAndScores(bsonID(9), 3, 3, 3)   // 09  | 4 weeks | 2 weeks ago (3/07) | 4/04
 	suite.storePatientAndScores(bsonID(10), 4, 5, 4)  // 0a  | 4 weeks | 4 weeks ago (2/22) | 3/21
 	suite.storePatientAndScores(bsonID(11), 5, 4, 6)  // 0b  | 2 weeks | 1 week ago  (3/14) | 3/28 *
 	suite.storePatientAndScores(bsonID(12), 5, 6, 6)  // 0c  | 2 weeks | 3 weeks ago (2/29) | 3/21 (overdue)
-	suite.storePatientAndScores(bsonID(13), 6, 7, 6)  // 0d  | 2 weeks |                    | 3/21 (overdue)
+	suite.storePatientAndScores(bsonID(13), 6, 7, 6)  // 0d  | 2 weeks |                    | 3/28 (at latest)
 	suite.storePatientAndScores(bsonID(14), 8, 8, 7)  // 0e  | 2 weeks | 1 week ago  (3/14) | 3/28
 	suite.storePatientAndScores(bsonID(15), 5, 6, 7)  // 0f  | 2 weeks | 2 weeks ago (3/07) | 3/21
-	suite.storePatientAndScores(bsonID(16), 9, 9, 9)  // 10  | 1 week  |                    | 3/21 (overdue)
+	suite.storePatientAndScores(bsonID(16), 9, 9, 9)  // 10  | 1 week  |                    | 3/21
 	suite.storePatientAndScores(bsonID(17), 8, 9, 8)  // 11  | 1 week  | 1 week ago  (3/14) | 3/21
 	suite.storePatientAndScores(bsonID(18), 7, 7, 8)  // 12  | 1 week  | 2 weeks ago (3/07) | 3/21
 	suite.storePatientAndScores(bsonID(19), 9, 9, 9)  // 13  | 1 week  | 1 week ago  (3/14) | 3/21 *
@@ -97,18 +97,18 @@ func (suite *HuddleSchedulerSuite) TestCreatePopulatedHuddleForNewHuddle() {
 	ha.AssertActiveDateTimeEqual(time.Date(2016, time.March, 21, 0, 0, 0, 0, time.UTC))
 	ha.AssertLeaderIDEqual("123")
 	ha.AssertNameEqual("Test Huddle Config")
-	assert.Len(group.Member, 13)
+	assert.Len(group.Member, 11)
 
 	members := ha.HuddleMembers()
-	assert.Len(members, 13)
-	for _, id := range []string{bsonID(11), bsonID(19), bsonID(3), bsonID(13), bsonID(18), bsonID(8), bsonID(12),
-		bsonID(17), bsonID(20), bsonID(10), bsonID(15), bsonID(16), bsonID(7)} {
+	assert.Len(members, 11)
+	for _, id := range []string{bsonID(3), bsonID(7), bsonID(10), bsonID(11), bsonID(12), bsonID(15), bsonID(16),
+		bsonID(17), bsonID(18), bsonID(19), bsonID(20)} {
 		assert.NotNil(ha.FindHuddleMember(id))
 	}
 	ha.AssertMember(0, bsonID(11), recentEncounterReason("Emergency Room Visit"))
 	ha.AssertMember(1, bsonID(19), recentEncounterReason("Emergency Room Visit"))
 	ha.AssertMember(2, bsonID(3), recentEncounterReason("Hospital Discharge"))
-	for i := 3; i < 13; i++ {
+	for i := 3; i < 11; i++ {
 		assert.Equal(riskScoreReason(), members[i].Reason())
 	}
 }
@@ -150,7 +150,7 @@ func (suite *HuddleSchedulerSuite) TestCreatePopulatedHuddleForExistingHuddle() 
 
 	// PATIENT                                      // Hex | FREQ.   | LAST HUDDLE        | DUE BY
 	suite.storePatientAndScores(bsonID(1), 1, 1, 1) // 01  | never   |                    |
-	suite.storePatientAndScores(bsonID(2), 5, 5, 4) // 02  | 4 weeks |                    | 4/04 (mod 3)
+	suite.storePatientAndScores(bsonID(2), 5, 5, 4) // 02  | 4 weeks |                    | 4/11 (at latest)
 	suite.storePatientAndScores(bsonID(3), 8, 8, 7) // 03  | 2 weeks | 1 week ago  (3/14) | 3/28
 	suite.storePatientAndScores(bsonID(4), 8, 9, 8) // 04  | 1 week  | 1 week ago  (3/14) | 3/21
 
@@ -203,19 +203,20 @@ func (suite *HuddleSchedulerSuite) TestScheduleHuddlesByRiskScore() {
 	// Now check each one individually
 	ha := NewHuddleAssertions(huddles[0], assert)
 	ha.AssertActiveDateTimeEqual(t)
-	ha.AssertMemberIDs(bsonID(1), bsonID(3), bsonID(4))
+	ha.AssertMemberIDs(bsonID(4), bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(4))
+	ha.AssertMemberIDs(bsonID(4), bsonID(5))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
-	ha.AssertMemberIDs(bsonID(1), bsonID(4), bsonID(5))
+	ha.AssertMemberIDs(bsonID(4), bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[3], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 21))
-	ha.AssertMemberIDs(bsonID(4))
+	// Patient 3 comes first because they're both due, but 3 has never been discussed before
+	ha.AssertMemberIDs(bsonID(3), bsonID(4))
 
 	// Now just make sure they were really stored to the db
 	var storedHuddles []*models.Group
@@ -320,10 +321,8 @@ func (suite *HuddleSchedulerSuite) TestScheduleHuddlesByEncounterEventsWithResch
 
 	// Do this five times just to ensure the same results every time
 	for i := 0; i < 5; i++ {
-		fmt.Println("Do Round", i+1)
 		huddles, err := ScheduleHuddles(config)
 		require.NoError(err)
-		fmt.Println("Check Round", i+1)
 		assert.Len(huddles, 4)
 
 		// Now check each huddle
@@ -383,19 +382,19 @@ func (suite *HuddleSchedulerSuite) TestManuallyAddPatientToExistingHuddle() {
 	// Check each one individually to ensure it's as expected
 	ha := NewHuddleAssertions(huddles[0], assert)
 	ha.AssertActiveDateTimeEqual(t)
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[3], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 21))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	// Now manually schedule patient 2 to the first huddle (which should be an off-week for the patient)
 	huddles[0].Member = append(huddles[0].Member, models.GroupMemberComponent{
@@ -486,19 +485,19 @@ func (suite *HuddleSchedulerSuite) TestManuallyAddMultiplePatientsToTodaysHuddle
 	// Check each one individually to ensure it's as expected
 	ha := NewHuddleAssertions(huddles[0], assert)
 	ha.AssertActiveDateTimeEqual(t)
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[3], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 21))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	// Now manually schedule patients to today's huddle
 	huddles[0].Member = append(huddles[0].Member, models.GroupMemberComponent{
@@ -571,7 +570,8 @@ func (suite *HuddleSchedulerSuite) TestManuallyAddMultiplePatientsToTodaysHuddle
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	// Patent 2 comes first since he never had a huddle before
+	ha.AssertMemberIDs(bsonID(2), bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
@@ -621,19 +621,19 @@ func (suite *HuddleSchedulerSuite) TestManuallyAddPatientToTodaysHuddle() {
 	// Check each one individually to ensure it's as expected
 	ha := NewHuddleAssertions(huddles[0], assert)
 	ha.AssertActiveDateTimeEqual(t)
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
-	ha.AssertMemberIDs(bsonID(1))
+	ha.AssertMemberIDs(bsonID(1), bsonID(2))
 
 	ha = NewHuddleAssertions(huddles[3], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 21))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	ha.AssertMemberIDs(bsonID(1))
 
 	// Now manually schedule patient 3 to today's huddle
 	huddles[0].Member = append(huddles[0].Member, models.GroupMemberComponent{
@@ -677,7 +677,8 @@ func (suite *HuddleSchedulerSuite) TestManuallyAddPatientToTodaysHuddle() {
 
 	ha = NewHuddleAssertions(huddles[1], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 7))
-	ha.AssertMemberIDs(bsonID(1), bsonID(2))
+	// Patent 2 comes first since he never had a huddle before
+	ha.AssertMemberIDs(bsonID(2), bsonID(1))
 
 	ha = NewHuddleAssertions(huddles[2], assert)
 	ha.AssertActiveDateTimeEqual(t.AddDate(0, 0, 14))
@@ -702,20 +703,20 @@ func (suite *HuddleSchedulerSuite) TestRollOverPatientsToTodaysHuddle() {
 	// The three unreviewed patients (2, 3, and 5) should roll over to today's huddle -- but since 5 was scheduled
 	// anyway, don't call it a rollover.
 	require.Len(ha.Member, 4)
-	ha.AssertMember(0, bsonID(4), riskScoreReason())
-	ha.AssertMember(1, bsonID(5), riskScoreReason())
-	ha.AssertMember(2, bsonID(2), &models.CodeableConcept{
+	ha.AssertMember(0, bsonID(2), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Manually Added - I've got a hunch)", lastHuddle.Format("Jan 2")),
 	})
-	ha.AssertMember(3, bsonID(3), &models.CodeableConcept{
+	ha.AssertMember(1, bsonID(3), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", lastHuddle.Format("Jan 2")),
 	})
+	ha.AssertMember(2, bsonID(4), riskScoreReason())
+	ha.AssertMember(3, bsonID(5), riskScoreReason())
 }
 
 func (suite *HuddleSchedulerSuite) TestRollOverPatientsToNextHuddle() {
@@ -728,20 +729,20 @@ func (suite *HuddleSchedulerSuite) TestRollOverPatientsToNextHuddle() {
 	// The three unreviewed patients (2, 3, and 5) should roll over to tomorrow's huddle -- but since 5 was scheduled
 	// anyway, don't call it a rollover.
 	require.Len(ha.Member, 4)
-	ha.AssertMember(0, bsonID(4), riskScoreReason())
-	ha.AssertMember(1, bsonID(5), riskScoreReason())
-	ha.AssertMember(2, bsonID(2), &models.CodeableConcept{
+	ha.AssertMember(0, bsonID(2), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Manually Added - I've got a hunch)", lastHuddle.Format("Jan 2")),
 	})
-	ha.AssertMember(3, bsonID(3), &models.CodeableConcept{
+	ha.AssertMember(1, bsonID(3), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", lastHuddle.Format("Jan 2")),
 	})
+	ha.AssertMember(2, bsonID(4), riskScoreReason())
+	ha.AssertMember(3, bsonID(5), riskScoreReason())
 }
 
 func (suite *HuddleSchedulerSuite) TestRollOverPatientsAlreadyInTodaysHuddle() {
@@ -754,35 +755,35 @@ func (suite *HuddleSchedulerSuite) TestRollOverPatientsAlreadyInTodaysHuddle() {
 	reasonMap := map[string]*models.CodeableConcept{
 		bsonID(99): rollOverReason(existingROFromDate, riskScoreReason()),
 	}
-	suite.storeHuddleWithDetails(today(), "123", riskScoreReason(), reasonMap, nil, bsonID(7), bsonID(99))
+	suite.storeHuddleWithDetails(today(), "123", riskScoreReason(), reasonMap, nil, bsonID(98), bsonID(99))
 
 	// Then setup the rollover stuff
 	lastHuddle := today().AddDate(0, 0, -3)
 	ha := suite.setupAndStartRollOverTest(3, lastHuddle, today())
 
-	// First, should be the risk score patients (4, 5 -- no longer 98 since risk score went down to 2), then the
-	// previously rolled over patient (99), then new rollover patients (2, 3).
+	// First, should be the previously rolled over patient (99), then new rollover patients (2, 3), then the risk score
+	// patients (4, 5 -- no longer 98 since risk score went down to 2).
 	require.Len(ha.Member, 5)
-	ha.AssertMember(0, bsonID(4), riskScoreReason())
-	ha.AssertMember(1, bsonID(5), riskScoreReason())
-	ha.AssertMember(2, bsonID(99), &models.CodeableConcept{
+	ha.AssertMember(0, bsonID(99), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", existingROFromDate.Format("Jan 2")),
 	})
-	ha.AssertMember(3, bsonID(2), &models.CodeableConcept{
+	ha.AssertMember(1, bsonID(2), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Manually Added - I've got a hunch)", lastHuddle.Format("Jan 2")),
 	})
-	ha.AssertMember(4, bsonID(3), &models.CodeableConcept{
+	ha.AssertMember(2, bsonID(3), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", lastHuddle.Format("Jan 2")),
 	})
+	ha.AssertMember(3, bsonID(4), riskScoreReason())
+	ha.AssertMember(4, bsonID(5), riskScoreReason())
 }
 
 func (suite *HuddleSchedulerSuite) TestRollOverPatientsGetNewReasonIfApplicable() {
@@ -795,7 +796,7 @@ func (suite *HuddleSchedulerSuite) TestRollOverPatientsGetNewReasonIfApplicable(
 	reasonMap := map[string]*models.CodeableConcept{
 		bsonID(99): rollOverReason(existingROFromDate, riskScoreReason()),
 	}
-	suite.storeHuddleWithDetails(today(), "123", riskScoreReason(), reasonMap, nil, bsonID(7), bsonID(99))
+	suite.storeHuddleWithDetails(today(), "123", riskScoreReason(), reasonMap, nil, bsonID(98), bsonID(99))
 
 	// Then setup the rollover stuff
 	lastHuddle := today().AddDate(0, 0, -3)
@@ -803,22 +804,22 @@ func (suite *HuddleSchedulerSuite) TestRollOverPatientsGetNewReasonIfApplicable(
 
 	// The previously rolled over patient should not show RO as a reason since Risk Score brings him up again anyway
 	require.Len(ha.Member, 6)
-	ha.AssertMember(0, bsonID(4), riskScoreReason())
-	ha.AssertMember(1, bsonID(5), riskScoreReason())
-	ha.AssertMember(2, bsonID(98), riskScoreReason())
-	ha.AssertMember(3, bsonID(99), riskScoreReason())
-	ha.AssertMember(4, bsonID(2), &models.CodeableConcept{
+	ha.AssertMember(0, bsonID(2), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Manually Added - I've got a hunch)", lastHuddle.Format("Jan 2")),
 	})
-	ha.AssertMember(5, bsonID(3), &models.CodeableConcept{
+	ha.AssertMember(1, bsonID(3), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", lastHuddle.Format("Jan 2")),
 	})
+	ha.AssertMember(2, bsonID(98), riskScoreReason())
+	ha.AssertMember(3, bsonID(99), riskScoreReason())
+	ha.AssertMember(4, bsonID(4), riskScoreReason())
+	ha.AssertMember(5, bsonID(5), riskScoreReason())
 }
 
 func (suite *HuddleSchedulerSuite) TestRollOverPatientsWithNoRollOverConfigured() {
@@ -913,11 +914,11 @@ func (suite *HuddleSchedulerSuite) TestInProgressHuddleIsntOverwritten() {
 
 	// PATIENT                                      // Hex | FREQ.   | LAST HUDDLE | DUE BY
 	suite.storePatientAndScores(bsonID(1), 1, 1, 1) // 01  | never   |             |
-	suite.storePatientAndScores(bsonID(2), 5, 5, 4) // 02  | 4 weeks |             | Today (overdue)
-	suite.storePatientAndScores(bsonID(3), 8, 8, 7) // 03  | 2 weeks | 3 days ago  | 11 days from today
-	suite.storePatientAndScores(bsonID(4), 8, 9, 8) // 04  | 1 week  | 3 days ago  | 4 days from today
-	suite.storePatientAndScores(bsonID(5), 8, 9, 8) // 05  | 1 week  | 3 days ago  | 4 days from today
-	suite.storePatientAndScores(bsonID(6), 8, 8, 7) // 06  | 2 weeks | 3 days ago  | 11 days from today
+	suite.storePatientAndScores(bsonID(2), 5, 5, 4) // 02  | 4 weeks |             | 3 huddles from today
+	suite.storePatientAndScores(bsonID(3), 8, 8, 7) // 03  | 2 weeks | 3 days ago  | 1 huddle from today
+	suite.storePatientAndScores(bsonID(4), 8, 9, 8) // 04  | 1 week  | 3 days ago  | today, then 1 huddle from today
+	suite.storePatientAndScores(bsonID(5), 8, 9, 8) // 05  | 1 week  | 3 days ago  | today, then 1 huddle from today
+	suite.storePatientAndScores(bsonID(6), 8, 8, 5) // 06  | 4 weeks | 3 days ago  | 3 huddles from today
 
 	lastHuddleDate := today().AddDate(0, 0, -3)
 	config := createHuddleConfig(true, true, 3, lastHuddleDate.Weekday(), today().Weekday())
@@ -951,28 +952,35 @@ func (suite *HuddleSchedulerSuite) TestInProgressHuddleIsntOverwritten() {
 		assert.True(strings.HasPrefix(ha.Name, "Test Huddle"))
 	}
 
-	// Now check the first one to ensure it's the right date -- which *shouldn't* be today
+	// Now check the first one to ensure it's the right date (today) -- but hasn't been modified
 	ha := NewHuddleAssertions(groups[0], assert)
+	ha.AssertActiveDateTimeEqual(today())
+	require.Len(ha.Member, 2)
+	ha.AssertMember(0, bsonID(1), riskScoreReason())
+	ha.AssertMember(1, bsonID(2), riskScoreReason())
+	assert.Equal(today(), ha.FindHuddleMember(bsonID(2)).Reviewed().Time)
+
+	// Now check the one after today to ensure it's as expected
+	ha = NewHuddleAssertions(groups[1], assert)
 	ha.AssertActiveDateTimeEqual(today().AddDate(0, 0, 4))
-
-	// And check all the others to make sure they *don't* have rollover patients
-	for i := 1; i < 3; i++ {
-		for _, member := range groups[i].Member {
-			hm := HuddleMember(member)
-			assert.False(hm.ReasonIsRollOver())
-		}
-	}
-
-	// And last, check that the next huddle (not today) has everything we expect
-	require.Len(ha.Member, 3)
-	ha.AssertMember(0, bsonID(4), riskScoreReason())
-	ha.AssertMember(1, bsonID(5), riskScoreReason())
-	ha.AssertMember(2, bsonID(6), &models.CodeableConcept{
+	require.Len(ha.Member, 4)
+	ha.AssertMember(0, bsonID(6), &models.CodeableConcept{
 		Coding: []models.Coding{
 			models.Coding{System: "http://interventionengine.org/fhir/cs/huddle-member-reason", Code: "ROLLOVER"},
 		},
 		Text: fmt.Sprintf("Rolled Over from %s (Risk Score Warrants Discussion)", lastHuddleDate.Format("Jan 2")),
 	})
+	ha.AssertMember(1, bsonID(4), riskScoreReason())
+	ha.AssertMember(2, bsonID(5), riskScoreReason())
+	ha.AssertMember(3, bsonID(3), riskScoreReason())
+
+	// And check all the others to make sure they *don't* have rollover patients
+	for i := 2; i < 4; i++ {
+		for _, member := range groups[i].Member {
+			hm := HuddleMember(member)
+			assert.False(hm.ReasonIsRollOver())
+		}
+	}
 }
 
 func createHuddleConfig(inclRisk bool, inclEvents bool, rollOverDelay int, days ...time.Weekday) *HuddleConfig {
@@ -1314,7 +1322,6 @@ func (h *HuddleAssertions) AssertMember(i int, id string, reason *models.Codeabl
 		External:     new(bool),
 	}, h.Member[i].Entity)
 	if reason != nil {
-		status = status && h.assert.Len(h.Member[i].Extension, 1)
 		status = status && h.assert.Equal(reason, h.HuddleMembers()[i].Reason())
 	}
 	return status


### PR DESCRIPTION
A new approach to scheduling huddles to ensure a more evenly distributed huddle size ("balanced huddles").

This approach allows the huddle configuration to specify ideal frequencies (e.g., every 3 huddles), minimum frequencies (e.g., no more often than every 2 huddles), and maximum frequencies (e.g., no less often than every 4 huddles).

The scheduler first calculates the target huddle size, then it schedules one huddle at a time.  First it adds some REQUIRED patients: manually added patients, patients with recent encounters, rolled over patients, and patients who are due or overdue for a huddle based on their risk score.  Then, if it still has room to reach the target huddle size, it continues adding patients based on their ideal huddle dates.

This changes how patients are scheduled, as well as the order in which they're scheduled, so it affected many existing unit tests as well.
