### PR TITLE
Fix Dev Instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.7
 ADD . /go/src/github.com/intervention-engine/ie
 
 #Build the Intervention Engine server
-WORKDIR /go/src/github.com/intervention-engine/ie
+WORKDIR /go/src/github.com/intervention-engine/ie/cmd/ie
 RUN go build main.go
 
 # Document that the service listens on port 3001.

--- a/docs/dev_install.md
+++ b/docs/dev_install.md
@@ -286,8 +286,9 @@ Build and Run Intervention Engine Server
 Before you can run the Intervention Engine server, you must build the `ie` executable:
 
 ```
-$ cd $GOPATH/src/github.com/intervention-engine/ie
+$ cd $GOPATH/src/github.com/intervention-engine/ie/cmd/ie
 $ go build
+$ cd ../..
 ```
 
 The above commands do not need to be run again unless you make (or download) changes to the *ie* or *fhir* source code.
@@ -297,7 +298,7 @@ To support automatic huddle scheduling, you must pass the `ie` executable a `-hu
 In addition, the first time you run the `ie` executable, you should also pass the `-loadCodes` option to load the ICD-9 and ICD-10 codes that are needed for the ICD-9/ICD-10 auto-complete feature:
 
 ```
-$ ./ie -huddle ./config/multifactor_huddle_config.json -loadCodes
+$ ./cmd/ie/ie -huddle ./config/multifactor_huddle_config.json -loadCodes
 ```
 
 Automatic huddle scheduling will happen at the times indicated by the cron expression in the huddle configuration file.  You can also force huddles to be rescheduled by performing an HTTP GET on [http://localhost:3001/ScheduleHuddles](http://localhost:3001/ScheduleHuddles).
@@ -305,13 +306,13 @@ Automatic huddle scheduling will happen at the times indicated by the cron expre
 Subsequent runs of *ie* do not need to load the codes again:
 
 ```
-$ ./ie -huddle ./config/multifactor_huddle_config.json
+$ ./cmd/ie/ie -huddle ./config/multifactor_huddle_config.json
 ```
 
 If you are concurrently modifying the *ie* source code, sometimes it is easier to combine the build and run steps into a single command (forcing a recompile on every run):
 
 ```
-$ go run server.go -huddle ./config/multifactor_huddle_config.json
+$ go run cmd/ie/*.go -huddle config/multifactor_huddle_config.json
 ```
 
 The *ie* server accepts connections on port 3001 by default.


### PR DESCRIPTION
The instructions for building and running IE weren't updated when
then main files were migrated to cmd/ie. This make the docs
accurate again.

Also fix similar issue in Dockerfile